### PR TITLE
Details

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,8 @@ gulp.task('help', function() {
 
 gulp.task('sasslint', function() {
     return gulp.src('scss/*.scss')
-        .pipe(scsslint())
+        .pipe(scsslint({ 'config' : 'lint.yml' }))
+        .pipe(scsslint.failReporter())
 });
 
 gulp.task('sass', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,6 @@ gulp.task('sasslint', function() {
 
 gulp.task('sass', function() {
     return gulp.src('scss/*.scss')
-        .pipe(scsslint({ 'config' : 'lint.yml' }))
         .pipe(sass({ style: 'expanded' }))
         .on('error', function (err) { console.log(err.message); })
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
@@ -39,7 +38,7 @@ gulp.task('docs', function() {
         .pipe(sassdoc({ 'dest': 'build/docs'}));
 });
 
-gulp.task('build', ['sass', 'docs']);
+gulp.task('build', ['sasslint', 'sass', 'docs']);
 
 gulp.task('sass-lite', function() {
     return gulp.src('scss/ubuntu-styles.scss')


### PR DESCRIPTION
Details
===
Currently Travis isn't failing, even though there's
a syntax error in the sass.

This should fix that by making `gulp sasslint` return
an error state properly when something fails.

Done
---
- Separate `sasslint` from `sass` gulp commands
- Add FailReporter to `sasslint`

QA
---
- Run `gulp test` or `node_modules/gulp/bin/gulp.js test`
- Run `echo $?` - should return '1' to show an error state
- Also the Travis build task for this PR should *fail*