### PR TITLE
Travis sasslint fail state

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,28 @@
-
 var gulp = require('gulp')
     rename = require('gulp-rename'),
     sass = require('gulp-sass'),
     autoprefixer = require('gulp-autoprefixer'),
     notify = require('gulp-notify'),
+    gutil = require('gulp-util'),
     scsslint = require('gulp-scss-lint');
     minifycss = require('gulp-minify-css');
-    sassdoc = require('sassdoc');
+    sassdoc = require('sassdoc'),
+    util = require('util');
 
+/* Helper functions */
+function throwSassError(sassError) {
+    throw new gutil.PluginError({
+        plugin: 'sass',
+        message: util.format(
+            "Sass error: '%s' on line %s of %s",
+            sassError.message,
+            sassError.line,
+            sassError.file
+        )
+    });
+}
 
+/* Gulp instructions start here */
 gulp.task('help', function() {
     console.log('sass - Generate the min and unminified css from sass');
     console.log('docs - Generate the docs from the source sass');
@@ -25,8 +39,10 @@ gulp.task('sasslint', function() {
 
 gulp.task('sass', function() {
     return gulp.src('scss/*.scss')
-        .pipe(sass({ style: 'expanded' }))
-        .on('error', function (err) { console.log(err.message); })
+        .pipe(sass({
+            style: 'expanded',
+            onError: throwSassError
+        }))
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
         .pipe(gulp.dest('build/css/'))
         .pipe(rename({suffix: '.min'}))
@@ -43,8 +59,7 @@ gulp.task('build', ['sasslint', 'sass', 'docs']);
 
 gulp.task('sass-lite', function() {
     return gulp.src('scss/ubuntu-styles.scss')
-        .pipe(sass({ style: 'expanded' }))
-        .on('error', function (err) { console.log(err.message); })
+        .pipe(sass({ style: 'expanded', errLogToConsole: true }))
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
         .pipe(gulp.dest('build/css/'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,8 @@ gulp.task('help', function() {
 
 gulp.task('sasslint', function() {
     return gulp.src('scss/*.scss')
-        .pipe(scsslint())
+        .pipe(scsslint({ 'config' : 'lint.yml' }))
+        .pipe(scsslint.failReporter())
 });
 
 gulp.task('sass', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,6 @@ gulp.task('sasslint', function() {
 
 gulp.task('sass', function() {
     return gulp.src('scss/*.scss')
-        .pipe(scsslint({ 'config' : 'lint.yml' }))
         .pipe(sass({ style: 'expanded' }))
         .on('error', function (err) { console.log(err.message); })
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
@@ -39,7 +38,7 @@ gulp.task('docs', function() {
         .pipe(sassdoc({ 'dest': 'build/docs'}));
 });
 
-gulp.task('build', ['sass', 'docs']);
+gulp.task('build', ['sasslint', 'sass', 'docs']);
 
 gulp.task('sass-lite', function() {
     return gulp.src('scss/ubuntu-styles.scss')

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "gulp-sass": "^1.3.3",
     "gulp-scss-lint": "^0.1.7",
     "sassdoc": "^2.0.9"
+  },
+  "dependencies": {
+    "gulp-util": "^3.0.4"
   }
 }


### PR DESCRIPTION
Details
===
Currently Travis isn't failing, even though there's
a syntax error in the sass.

This should fix that by making `gulp sasslint` return
an error state properly when something fails.

Done
---
- Separate `sasslint` from `sass` gulp commands
- Add FailReporter to `sasslint`
- The Gulp Sass target will now return an error status, with a useful error message
- The sass-lite target will return an error in a simpler and more useful way (without breaking watch)

QA
---

Run the following:

``` bash
npm install
node_modules/gulp/bin/gulp.js test || echo "successfully returned an error"
node_modules/gulp/bin/gulp.js sass || echo "successfully returned an error"
```

As long as the Sass still has its syntax error, you should see `successfully returned an error` after the output of each command.

Then run `node_modules/gulp/bin/gulp.js watch`, change one of the sass files and confirm that you see an error message in the watcher without it breaking.