### PR TITLE
added scss-lint gem installstep to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 install:
+	sudo gem install scss-lint
 	npm install


### PR DESCRIPTION
Is this the right thing to do, to bootstrap our gulp setup? Karl's errors were due to an old version of `scss-lint`, which can be installed or upgraded by this command.