### PR TITLE
Remove vendor prefixes for sasslint

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,8 +1,6 @@
 linters:
   Indentation:
     enabled: true
-  IdSelector:
-    enabled: false
   PropertySortOrder:
     enabled: false
   SelectorDepth:

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,6 +1,8 @@
 linters:
   Indentation:
     enabled: true
+  IdSelector:
+    enabled: false
   PropertySortOrder:
     enabled: false
   SelectorDepth:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ gulp.task('help', function() {
 
 gulp.task('sasslint', function() {
     return gulp.src('scss/*.scss')
-        .pipe(scsslint({ 'config' : 'lint.yml' }))
+        .pipe(scsslint())
         .pipe(scsslint.failReporter());
 });
 

--- a/scss/_core-grid-desktop.scss
+++ b/scss/_core-grid-desktop.scss
@@ -500,7 +500,7 @@
 
   .row,
   #context-footer { // Clear entire row.
-    @include rounded-corners(0);
+    border-radius: 0;
     margin: 0;
     padding: 40px 40px 20px;
   }
@@ -522,7 +522,7 @@
 
   // inner grid
   .container {
-    @include box-sizing;
+    box-sizing: border-box;
     margin: $gutter-width $gutter-width 0;
     width: 100%;
   }

--- a/scss/_core-grid-tablet.scss
+++ b/scss/_core-grid-tablet.scss
@@ -519,7 +519,7 @@
 
   .row, 
   #context-footer { // Clear entire row
-    @include rounded-corners(0);
+    border-radius: 0;
     margin: 0;
     padding: 40px 40px 20px;
   }
@@ -541,7 +541,7 @@
 
   // inner grid
   .container {
-    @include box-sizing;
+    box-sizing: border-box;
     margin: $gutter-width $gutter-width 0;
     width: 100%;
   }

--- a/scss/_core-grid.scss
+++ b/scss/_core-grid.scss
@@ -63,7 +63,7 @@ body {
 .eleven-col, 
 .twelve-col, 
 .col {
-  @include box-sizing;
+  box-sizing: border-box;
   clear: none;
   display: inline-block;
   float: none;

--- a/scss/_core-grid.scss
+++ b/scss/_core-grid.scss
@@ -1,4 +1,5 @@
 @charset 'UTF-8';
+
 ////
 /// Ubuntu Core Front-End Framework
 ///

--- a/scss/_core-mixins.scss
+++ b/scss/_core-mixins.scss
@@ -9,36 +9,6 @@
   margin-bottom: (12 / $size)+em;
 }
 
-/// box-sizing with prefixes
-@mixin box-sizing ($type: border-box) {
-  -webkit-box-sizing: $type;
-  -moz-box-sizing: $type;
-  box-sizing: $type;
-}
-
-/// border-radius with prefixes
-@mixin rounded-corners($radius: 4px 4px 4px 4px) {
-  -webkit-border-radius: $radius;
-  -moz-border-radius: $radius;
-  border-radius: $radius;
-}
-
-/// box shadow with prefixes
-@mixin box-shadow($shadow...) {
-  -moz-box-shadow: $shadow;
-  -webkit-box-shadow: $shadow;
-  box-shadow: $shadow;
-}
-
-/// background gradient with prefixes
-@mixin gradient($from, $to) {
-  background-color: $to;
-  background-image: -moz-linear-gradient($from, $to);
-  background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from($from), to($to));
-  background-image: -webkit-linear-gradient($from, $to);
-  background-image: -o-linear-gradient($from, $to);
-}
-
 /// footer styles with parameterised backgrond image
 @mixin footer($background) {
   padding: $gutter-width $two-col $gutter-width $four-col;
@@ -58,32 +28,3 @@
     clear: both;
   }
 }
-
-/// CSS3 colunms
-@mixin columns($num: 3, $gap: 20) {
-  -moz-column-count: $num;
-  -moz-column-gap: ($gap / $base)em;
-  -webkit-column-count: $num;
-  -webkit-column-gap: ($gap / $base)em;
-  column-count: $num;
-  column-gap: ($gap / $base)em;
-}
-
-/// background-size with prefixes
-@mixin background-size($size: 100% 100%) {
-  -moz-background-size: $size;
-  -webkit-background-size: $size;
-  -o-background-size: $size;
-  background-size: $size;
-}
-
-/// transitions with prefixes: usage: @include transition(all, 0.3s, ease-in-out);
-@mixin transition($properties: all, $duration: .5s, $method: ease-out) {
-  -webkit-transition: $properties $duration $method;
-  -moz-transition: $properties $duration $method;
-  -ms-transition: $properties $duration $method;
-  -o-transition: $properties $duration $method;
-  transition: $properties $duration $method;
-}
-
-// usage: @include transition(all, 0.3s, ease-in-out);

--- a/scss/_core-templates.scss
+++ b/scss/_core-templates.scss
@@ -11,123 +11,12 @@
 /// @copyright  2012 Canonical Ltd
 ////
 
-/// Audience specific
-/// @section audience
-
-/// Consumer
-.audience-consumer {
-  color: $cool-grey;
-
-  .row-box, 
-  .main-content {
-    color: $cool-grey;
-  }
-
-  .inner-wrapper {
-    background: $white;
-  }
-
-  .quote-right-top {
-    background: url('/sites/ubuntu/latest/u/img/patterns/quote-orange-br-287x287.png') no-repeat;
-    height: 287px;
-    padding: 60px 60px 0 40px;
-    position: absolute;
-    right: -($gutter-width * 2);
-    text-align: left;
-    top: -($gutter-width * 4.5);
-    width: $four-col;
-
-    p {
-      @include font-size (16);
-      color: $white;
-      margin: (1.538em / 2);
-      padding-bottom: 0;
-
-      cite {
-        @include font-size (12);
-        color: $white;
-        padding: 0;
-      }
-    }
-  }
-
-  .quote-right-top p a,
-  .quote-right p a { 
-    color: $white; 
-  }
-
-  .quote-right {
-    @include font-size (18);
-    background: url('/sites/ubuntu/latest/u/img/patterns/quote-orange-bl-287x287.png') no-repeat;
-    color: $white;
-    min-height: 287px;
-    padding: 50px 100px 0 50px;
-    position: absolute;
-    right: -$gutter-width;
-    text-align: left;
-    text-indent: -6px;
-    top: -($gutter-width * 4.5);
-    width: $four-col -(150/$base)em;
-
-    cite {
-      font-style: normal;
-      margin-left: 6px;
-    }
-  }
-
-  .quote-right-alt {
-    background: url('/sites/ubuntu/latest/u/img/patterns/quote-white-br-360x360.png') 0 -100px no-repeat;
-    color: $ubuntu-orange;
-    padding: 50px 50px 0;
-  }
-
-  .quote-right-right { background: url('/sites/ubuntu/latest/u/img/patterns/quote-orange-br-287x287.png') no-repeat; }
-}
-
-/// Enterprise
-.audience-enterprise {
-
-  h1 { margin: 0 0 18px; }
-  td { background: $white; }
-
-  th, 
-  td {
-    background: $white;
-    padding: 6px 10px;
-  }
-
-  th[scope='col'] {
-    background: #e2d4dc;
-    color: $canonical-aubergine;
-  }
-
-  tbody th[rowspan] { background: #f7f2f6; }
-
-  tfoot th[rowspan] { background: #dfdcd9; }
-
-  tfoot td, 
-  tfoot th {
-    background: #dfdcd9;
-    font-weight: normal;
-  }
-
-  .inner-wrapper {
-    background: $dark-aubergine;
-    color: $white;
-  }
-
-  .row-box {
-    background: $white;
-    color: $cool-grey;
-  }
-}
-
 .row-enterprise {
   @include rounded-corners(0);
   background: $canonical-aubergine;
   color: $white;
 
-  .box, 
+  .box,
   div {
     background: $canonical-aubergine;
     color: $white;
@@ -138,5 +27,10 @@
   }
 }
 
-.enterprise-dot-pattern { background: url('/sites/ubuntu/latest/u/img/patterns/enterprise-dot-pattern.png'); }
-.developer-dot-pattern { background: url('/sites/ubuntu/latest/u/img/patterns/developer-dot-pattern.png'); }
+.enterprise-dot-pattern {
+  background: url('/sites/ubuntu/latest/u/img/patterns/enterprise-dot-pattern.png');
+}
+
+.developer-dot-pattern {
+  background: url('/sites/ubuntu/latest/u/img/patterns/developer-dot-pattern.png');
+}

--- a/scss/_core-templates.scss
+++ b/scss/_core-templates.scss
@@ -12,7 +12,7 @@
 ////
 
 .row-enterprise {
-  @include rounded-corners(0);
+  border-radius: 0;
   background: $canonical-aubergine;
   color: $white;
 

--- a/scss/_core.scss
+++ b/scss/_core.scss
@@ -155,11 +155,6 @@ audio:not([controls]) {
 @import url('//fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic%7CUbuntu+Mono');
 
 html {
-  -moz-transition: background-position 100 ease;
-  -ms-text-size-adjust: 100%;
-  -o-transition: background-position 100 ease;
-  -webkit-text-size-adjust: 100%;
-  -webkit-transition: background-position 100 ease;
   background: url('#{$asset-path}backgrounds/image-background-paper.png') repeat-y fixed center top $light-grey;
   font-size: 100%;
   overflow-y: scroll;
@@ -452,7 +447,7 @@ pre {
 }
 
 pre {
-  @include rounded-corners(4px);
+  border-radius: 4px;
   background: $light-orange;
   padding: .6em 1em;
   white-space: pre-wrap;
@@ -495,11 +490,8 @@ input[type='radio'] {
   padding: 0;
 }
 
-input[type='search'] {
-  @include rounded-corners(2px);
-  -moz-box-sizing: content-box;
-  -webkit-appearance: none;
-  -webkit-box-sizing: content-box;
+input[type="search"] {
+  border-radius: 2px;
   box-sizing: content-box;
   font-family: Ubuntu,Arial,'libra sans',sans-serif;
   font-weight: 300;
@@ -523,7 +515,7 @@ textarea {
 }
 
 form fieldset {
-  @include rounded-corners(4px);
+  border-radius: 4px;
   background-repeat: no-repeat;
   background-color: #efeeec;
   background-position: -15px -15px;
@@ -546,8 +538,7 @@ form input[type='text'],
 form input[type='email'],
 form input[type='tel'],
 form textarea {
-  -webkit-appearance: none;
-  @include rounded-corners(2px);
+  border-radius: 2px;
   background-color: $white;
   border: 1px solid #999;
   display: block;
@@ -580,9 +571,10 @@ form input[type='radio'] + label {
 
 form input[type='submit'] {
   @include font-size (16);
-  @include rounded-corners(4px);
-  @include gradient(#f26120, $ubuntu-orange);
-  @include box-shadow(none);
+  border-radius: 4px;
+  background-color: $ubuntu-orange;
+  background-image: linear-gradient(#f26120, $ubuntu-orange);
+  box-shadow: none;
   border: 0;
   color: $white;
   display: block;

--- a/scss/patterns/_blockquotes.scss
+++ b/scss/patterns/_blockquotes.scss
@@ -120,10 +120,10 @@ html.no-svg,
 // row-quote
 
 .row-quote {
-  @include rounded-corners(0);
+  border-radius: 0;
 
   blockquote {
-    @include rounded-corners(4px);
+    border-radius: 4px;
     margin: 0;
     padding: 0;
 

--- a/scss/patterns/_boxes.scss
+++ b/scss/patterns/_boxes.scss
@@ -1,7 +1,7 @@
 @charset 'UTF-8';
 
 %box {
-  @include rounded-corners(4px);
+  border-radius: 4px;
   padding: 1.333em $gutter-width;
 }
 
@@ -23,18 +23,18 @@
 }
 
 .box-highlight {
-	@include box-shadow(0 2px 2px 0 #c2c2c2);
+	box-shadow: 0 2px 2px 0 #c2c2c2;
 	border: 1px solid $light-grey;
 }
 
 .box-textured {
-  @include box-shadow(0 2px 2px 0 #c2c2c2);
+  box-shadow: 0 2px 2px 0 #c2c2c2;
   background: url("#{$asset-path}patterns/grey-textured-background.jpg");
   border: 0;
 }
 
 .box-padded {
-  @include rounded-corners(4px);
+  border-radius: 4px;
   background: $box-solid-grey;
   border: 0;
   margin-bottom: 20px;
@@ -52,7 +52,7 @@
   }
 
   div {
-    @include rounded-corners(4px);
+      border-radius: 4px;
       background: $white;
       overflow: hidden;
       padding: 8px 8px 2px;
@@ -60,7 +60,7 @@
 }
 
 .box-padded-feature {
-  @include rounded-corners(4px);
+  border-radius: 4px;
   background: url("#{$asset-path}patterns/soft-centre-bkg.gif") repeat scroll 0 0 #a09f9f;
   border: 0;
   margin-bottom: 20px;
@@ -78,7 +78,7 @@
   }
 
   > div {
-    @include rounded-corners(4px);
+    border-radius: 4px;
       background: $white;
       overflow: hidden;
       padding: 20px 8px;
@@ -112,8 +112,6 @@
   cursor: pointer;
   padding-bottom: 40px;
   position: relative;
-    -moz-transition: background .2s ease-out;
-    -webkit-transition: background .2s ease-out;
   transition: background .2s ease-out;
 
   & h2 {
@@ -145,19 +143,13 @@
   &:hover { background-color: #fafafa; }
 
   &:after {
-      -moz-box-shadow: 0 -1px 2px 0 #ddd;
-      -webkit-box-shadow: 0 -1px 2px 0 #ddd;
     box-shadow: 0 -1px 2px 0 #ddd;
     content: '';
     height: 1px;
     position: absolute;
     right: -6px;
     top: 14px;
-      -ms-transform: rotate(45deg);
-      -webkit-transform: rotate(45deg);
     transform: rotate(45deg);
-      -moz-transition: all .2s ease-out;
-      -webkit-transition: all .2s ease-out;
     transition: all .2s ease-out;
     width: 41px;
     z-index: 2;
@@ -172,8 +164,6 @@
   &:before {
     content: '';
     position: absolute;
-      -moz-transition: border-width .2s ease-out;
-      -webkit-transition: border-width .2s ease-out;
     transition: border-width .2s ease-out;
     top: -2px;
     right: -3px;
@@ -181,11 +171,9 @@
     height: 0;
     border-bottom: 30px solid #fdfdfd;
     border-right: 30px solid $white;
-    -webkit-box-shadow: -2px 2px 2px rgba(176, 176, 176, .4);
-    -moz-box-shadow: -2px 2px 2px rgba(176, 176, 176, .4);
     box-shadow: -2px 2px 2px rgba(176, 176, 176, .4);
     z-index: 2;
-    @include rounded-corners(0 0 0 0);
+    border-radius: 0;
   }
 
   &:hover:before {

--- a/scss/patterns/_buttons.scss
+++ b/scss/patterns/_buttons.scss
@@ -7,9 +7,9 @@ button.cta-ubuntu,
 button.cta-canonical,
 form button[type="submit"],
 form input[type="submit"] {
-	@include box-sizing();
+	box-sizing: border-box;
 	@include font-size (16);
-	@include rounded-corners(3px);
+	border-radius: 3px;
 	background: $ubuntu-orange;
 	color: $white;
 	text-decoration: none;
@@ -17,9 +17,6 @@ form input[type="submit"] {
 	margin: 0;
 	font-family: Ubuntu, Arial, 'libra sans', sans-serif;
 	font-weight: 300;
-	-webkit-font-smoothing: subpixel-antialiased;
-	-moz-font-smoothing: subpixel-antialiased;
-	-o-font-smoothing: subpixel-antialiased;
 	font-smoothing: subpixel-antialiased;
 	padding: 8px 14px;
 	width: 100%;

--- a/scss/patterns/_contextual-footer.scss
+++ b/scss/patterns/_contextual-footer.scss
@@ -1,7 +1,7 @@
 @charset 'UTF-8';
 
 #context-footer {
-	@include box-sizing;
+	box-sizing: border-box;
 	@include font-size (14);
 	border-bottom: 0;
 	clear: both;
@@ -14,7 +14,7 @@
 	width: 100%;
 
 	hr {
-		@include box-shadow(inset 0 2px 2px -2px #333);
+		box-shadow: inset 0 2px 2px -2px #333;
 		background: $ubuntu-orange;
 		height: 14px;
 		margin: 0 0 10px;

--- a/scss/patterns/_footer.scss
+++ b/scss/patterns/_footer.scss
@@ -5,8 +5,8 @@ body footer.global #nav-global li:first-of-type a {
 }
 
 footer.global {
-	@include box-sizing;
-	@include box-shadow(inset 0 2px 2px -1px #d3d3d3);
+	box-sizing: border-box;
+	box-shadow: inset 0 2px 2px -1px #d3d3d3;
 	background: none;
 	border-top: 0;
 	clear: both;
@@ -98,7 +98,7 @@ footer.global {
 	}
 
 	.top-link {
-    @include box-shadow(0 -4px 4px -4px rgba(0, 0, 0, 0.3) inset);
+    box-shadow: 0 -4px 4px -4px rgba(0, 0, 0, 0.3) inset;
     background: none repeat scroll 0 0 rgba(0, 0, 0, 0);
     border: 0 none;
     float: left;
@@ -110,7 +110,7 @@ footer.global {
     width: 100%;
 
     a {
-      @include box-sizing();
+      box-sizing: border-box;
       background-image: url("#{$asset-path}pictograms/picto-pack/picto-upload-warmgrey.svg");
       background-position: 10px center;
       background-repeat: no-repeat;
@@ -136,7 +136,7 @@ html.no-svg, .opera-mini {
 
 @media only screen and (max-width : 768px) {
 	footer.no-global .legal {
-    @include box-sizing(content-box);
+        box-sizing: content-box;
 		box-shadow: 0 2px 2px -1px #D3D3D3 inset;
 		padding-top: 10px;
 		margin-left: -10px;

--- a/scss/patterns/_forms.scss
+++ b/scss/patterns/_forms.scss
@@ -4,7 +4,7 @@ form {
 	input,
 	select,
 	textarea {
-		@include box-sizing();
+		box-sizing: border-box;
 		width: 100%;
 	}
 

--- a/scss/patterns/_header.scss
+++ b/scss/patterns/_header.scss
@@ -44,9 +44,6 @@ header.banner {
 			  position: relative;
 			  text-align: center;
 			  text-decoration: none;
-			    -webkit-font-smoothing: subpixel-antialiased;
-			    -moz-font-smoothing: subpixel-antialiased;
-			    -o-font-smoothing: subpixel-antialiased;
 			  font-smoothing: subpixel-antialiased;
 			}
 
@@ -58,7 +55,7 @@ header.banner {
 			li a:hover {
 				background: #e1662f;
 				border-top: 0;
-				@include box-shadow(inset 0 2px 2px -2px #777);
+				box-shadow: inset 0 2px 2px -2px #777;
 			}
 		} // end ul
 	} // nav-primary
@@ -77,7 +74,7 @@ header.banner .nav-toggle {
 	height: 48px;
 	text-indent: -99999px;
 	background-image: url(#{$asset-path}icons/navigation-menu-plain.svg);
-	@include background-size(25px auto);
+	background-size: 25px auto;
 	background-repeat: no-repeat;
 	background-position: center center;
 	cursor: pointer;
@@ -98,7 +95,7 @@ header.banner nav ul {
 	float: left;
 }
 header.banner .nav-primary.active {
-	@include box-shadow(0 1px 2px 1px rgba(120, 120, 120, 0.2));
+	box-shadow: 0 1px 2px 1px rgba(120, 120, 120, 0.2);
 	padding: 0;
 	border-bottom: 1px solid $nav-border-dark;
 }
@@ -118,7 +115,7 @@ header.banner .nav-primary ul li a:active {
 }
 
 header.banner .nav-primary ul li a:hover {
-	@include box-shadow(none);
+	box-shadow: none;
 	background-color: $nav-hover-bg;
 }
 header.banner .nav-primary ul li a.active {
@@ -303,7 +300,7 @@ html.no-svg, .opera-mini {
 	header.banner {
 		.nav-primary.nav-right .logo-ubuntu,
 		.logo-ubuntu {
-			@include background_size(20px 20px);
+			background-size: 20px 20px;
 			background: url('#{$asset-path}logos/logo-ubuntu_cof-white_orange-hex.svg') 0 50% no-repeat;
 			min-width: 0;
 			width: 38px;
@@ -323,11 +320,11 @@ html.no-svg, .opera-mini {
 
 @media only screen and (max-width : 768px) {
   header.banner .nav-primary {
-    @include box-shadow(0 1px 2px 1px rgba(0, 0, 0, 0.2));
+    box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.2);
   }
   
   header.banner .nav-primary.active {
-    @include box-shadow(none);
+    box-shadow: none;
     padding: 0;
   }
 
@@ -357,7 +354,7 @@ html.no-svg, .opera-mini {
   header.banner .nav-primary ul li a:link,
   header.banner .nav-primary ul li a:visited,
   header.banner .nav-primary ul li a:active {
-    @include box-sizing();
+    box-sizing: border-box;
     background: transparent;
     border: none;
     display: block;
@@ -383,7 +380,7 @@ html.no-svg, .opera-mini {
 	}	
 
   header.banner .nav-primary ul li a:hover {
-    @include box-shadow(none);
+    box-shadow: none;
   	background: lighten($nav_bg, 3%);
   }
   header.banner .nav-primary ul li a.active {
@@ -399,7 +396,7 @@ html.no-svg, .opera-mini {
   }
 
   header.banner .nav-primary ul li {
-    @include box-sizing();
+    box-sizing: border-box;
     background: transparent;
     border-bottom: 0;
     border-right: 1px solid $nav-border-dark;
@@ -420,7 +417,7 @@ html.no-svg, .opera-mini {
       width: 100%;
 
       li {
-        @include box-sizing();
+        box-sizing: border-box;
         width: 50%;
         margin: 0;
         float: left;
@@ -428,8 +425,6 @@ html.no-svg, .opera-mini {
         a,
         a:link,
         a:visited {
-          -moz-box-sizing: border-box;
-          -webkit-box-sizing: border-box;
           box-sizing: border-box;
           display: block;
           height: 100%;
@@ -453,7 +448,7 @@ html.no-svg, .opera-mini {
       padding-bottom: 20px;
 
       li {
-        @include box-sizing();
+        box-sizing: border-box;
         width: 50%;
         margin: 0;
         float: left;
@@ -462,7 +457,7 @@ html.no-svg, .opera-mini {
         a,
         a:link,
         a:visited {
-          @include box-sizing();
+          box-sizing: border-box;
           padding: 10px 10px 10px 0;
           display: block;
           width: 100%;
@@ -489,7 +484,7 @@ html.no-svg, .opera-mini {
     } /* end third-level-nav */
 
     ul.breadcrumb {
-      @include box-sizing();
+      box-sizing: border-box;
       width: 100%;
       margin-left: 0;
       margin-bottom: 0;
@@ -500,7 +495,7 @@ html.no-svg, .opera-mini {
       }
 
       li {
-        @include box-sizing();
+        box-sizing: border-box;
         color: $white;
         width: 100%;
         display: block;
@@ -510,7 +505,7 @@ html.no-svg, .opera-mini {
         a,
         a:link,
         a:visited {
-          @include box-sizing();
+          box-sizing: border-box;
           font-size: 16px;
           width: 100%;
           color: #333333;
@@ -693,13 +688,9 @@ html.no-svg, .opera-mini {
 @media only screen and (min-width : 769px) {
 
   header.banner {
-      -moz-box-shadow: 0 2px 2px -2px #777777 inset, 2px 1px $white;
-      -webkit-box-shadow: 0 2px 2px -2px #777777 inset, 2px 1px $white;
     box-shadow: 0 2px 2px -2px #777777 inset, 2px 1px $white;
 
     nav.nav-primary {
-        -moz-box-shadow: none;
-        -webkit-box-shadow: none;
       box-shadow: none;
 			border-bottom: 0;
 
@@ -797,8 +788,8 @@ html.no-svg, .opera-mini {
 header.banner .nav-primary ul { position: static; }
 
 header.banner .nav-primary li ul {
-	@include box_shadow(0 2px 2px -1px #777777);
-	@include rounded_corners(10px);
+	box-shadow: 0 2px 2px -1px #777777;
+	border-radius: 10px;
 	background: #f7f7f7;
 	border: 1px solid #d5d5d5;
 	display: none;
@@ -825,7 +816,7 @@ header.banner .nav-primary li:hover ul:after {
 
 // show secondary nav differently if :after isn't supported, remove arrow and move secondary nav up to meet the bottom of the navbar
 .no-generatedcontent header.banner .nav-primary li ul {
-	@include rounded_corners(0 0 10px 10px);
+	border-radius: 0 0 10px 10px;
 	top: 48px;
 }
 
@@ -848,7 +839,7 @@ header.banner .nav-primary li ul li a:visited {
 }
 header.banner .nav-primary li ul li a:hover {
     background: none repeat scroll 0 0 transparent;
-    @include box_shadow(none);
+    box-shadow: none;
     color: #DD4814;
 }
 header.banner .nav-primary li ul li.first a:link,
@@ -884,7 +875,7 @@ header.banner .nav-primary li ul .promo a:hover {
 header.banner .nav-primary li ul .promo img {
     margin-top: 14px;
     margin-bottom: -6px;
-    @include rounded_corners(0 0 10px 10px);
+    border-radius: 0 0 10px 10px;
     position:relative;
     top:1px;
 }

--- a/scss/patterns/_helpers.scss
+++ b/scss/patterns/_helpers.scss
@@ -26,7 +26,7 @@ img {
 
 
 a.external {
-  @include background-size(.7em .7em);
+  background-size: .7em .7em;
   padding-right: .9em;
   background-image: url('#{$asset-path}external-link-orange.svg');
   background-position: right 1px;
@@ -78,7 +78,7 @@ a.external {
 }
 
 .box .pull-bottom-right {
-  @include rounded-corners(0 0 4px 0);
+  border-radius: 0 0 4px 0;
 }
 
 .pull-bottom-left { margin-left: -20px; margin-bottom: -21px; }

--- a/scss/patterns/_image-centered.scss
+++ b/scss/patterns/_image-centered.scss
@@ -57,7 +57,7 @@ div.row.row-image-centered {
 	div.row-image-centered,
 	div.row.row-image-centered,
 	div.box-image-centered {
-		@include box-sizing;
+		box-sizing: border-box;
 		padding-bottom: 20px;
 		display: table;
 
@@ -101,8 +101,6 @@ div.row.row-image-centered {
 		http://caniuse.com/transforms2d
 	*/
 	.js .align-vertically {
-		-moz-transform-style: preserve-3d;
-		-webkit-transform-style: preserve-3d;
 		transform-style: preserve-3d;
 		
 		img, 
@@ -148,7 +146,7 @@ div.box-image-centered {
 	div.row-image-centered,
 	div.row.row-image-centered,
 	div.box-image-centered {
-		@include box-sizing;
+		box-sizing: border-box;
 		padding: 60px 40px 60px;
 		display: table;
 

--- a/scss/patterns/_inline-logos.scss
+++ b/scss/patterns/_inline-logos.scss
@@ -19,7 +19,7 @@ ul.inline-logos {
 	  &.last-item { border: 0; }
 	}
 	img {
-		@include transition;
+		transition: all .5s ease-out;
 		vertical-align: middle;
 	  max-width: 115px;
 	  max-height: 32px;

--- a/scss/patterns/_rows.scss
+++ b/scss/patterns/_rows.scss
@@ -17,7 +17,7 @@
 // row
 // ----------------------------------------------------------
 .row {
-  @include box-sizing;
+  box-sizing: border-box;
   border-bottom: 1px dotted $warm-grey;
   clear: both;
   padding: 20px 10px 0;
@@ -83,8 +83,6 @@
 
   .resource {
     color: $cool-grey;
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
     box-shadow: none;
   }
 

--- a/scss/patterns/_search.scss
+++ b/scss/patterns/_search.scss
@@ -8,10 +8,10 @@
     input[type="search"],
     input[type="text"] {
 			-webkit-appearance: none;
-			@include box-shadow(inset 0 1px 4px rgba(0,0,0,0.2));
-			@include box-sizing();
-			@include rounded-corners(4px);
-			@include transition;
+			box-shadow: inset 0 1px 4px rgba(0,0,0,0.2);
+			box-sizing: border-box;
+			border-radius: 4px;
+			transition: all .5s ease-out;
 			background-color: #be3d00;
 			border: none;
 			color: $white;
@@ -76,7 +76,7 @@
 }
 
 header.banner .search-toggle {
-	@include background-size(20px 20px);
+	background-size: 20px 20px;
 	background-image: url('#{$asset-path}search_icon_white_64.png');
 	background-image: url('#{$asset-path}search.svg');
 	background-position: center center;
@@ -117,8 +117,7 @@ header.banner .search-toggle {
 
 #box-search div,
 .header-search div {
-	@include box-shadow( 	inset 0 -4px 4px -4px rgba(0, 0, 0, .3), 
-												inset 0  5px 5px -5px rgba(0, 0, 0, 0.3));
+	box-shadow:	inset 0 -4px 4px -4px rgba(0, 0, 0, .3), inset 0  5px 5px -5px rgba(0, 0, 0, 0.3);
 	background: $nav-bg;
 	margin: 10px;
 	position: relative;
@@ -128,11 +127,9 @@ header.banner .search-toggle {
 #box-search form input[type="search"],
 .header-search form input[type="search"] {
 	@include font-size (16);
-	@include rounded-corners();
-  @include box-shadow(0 2px 2px rgba(0, 0, 0, 0.3) inset,
-											0 -1px 3px rgba(0, 0, 0, 0.2) inset,
-											0 2px 0 rgba(255, 255, 255, 0.4));
-	@include box-sizing();
+	border-radius: 4px;
+    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3) inset, 0 -1px 3px rgba(0, 0, 0, 0.2) inset, 0 2px 0 rgba(255, 255, 255, 0.4);
+	box-sizing: border-box;
 	background: $white;
 	border: 0;
 	color: #333;
@@ -149,7 +146,7 @@ header.banner .search-toggle {
 	display: none;
 
 	form {
-		@include box-sizing();
+		box-sizing: border-box;
 		margin-left: 0;
 		margin-right: 0;
 		overflow: hidden;
@@ -201,8 +198,8 @@ header.banner .search-toggle {
 	
     form input[type="text"],
     form input[type="search"] {
-    	@include box-shadow(0 2px 4px rgba(0, 0, 0, 0.4) inset);
-      @include box-sizing(content-box);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4) inset;
+      box-sizing: content-box;
       background: url("#{$asset-path}icons/icon-search.png") no-repeat scroll 5px center, none repeat scroll 0 0 #BE3D00;
       border: 6px solid #DE6532;
       border-width: 0 0 1px;
@@ -271,7 +268,6 @@ header.banner .search-toggle {
 
 	.opera-mini {
 		x:-o-prefocus, header.banner .search-toggle {
-		  -o-background-size: 25px auto;
 		  background-size: 25px auto;
 		}
 	}
@@ -327,7 +323,6 @@ body.search-no-results {
 			width: 100%;
 			font-size: 2em;
 			border: 1px solid #999;
-			-moz-box-sizing: border-box;
 			box-sizing: border-box;
 			padding: 0.2em 65px 0.2em 0.2em;
 		}
@@ -428,7 +423,6 @@ body.search-no-results {
 		background-color: #fdffdc;
 		color: #333;
 		padding: 20px;
-		-moz-box-sizing: border-box;
 		box-sizing: border-box;
 		width: 100%;
 		margin-top: 20px;

--- a/scss/patterns/_slider.scss
+++ b/scss/patterns/_slider.scss
@@ -1,7 +1,7 @@
 @charset 'UTF-8';
 
 .slider {
-  @include rounded-corners(4px);
+  border-radius: 4px;
   background: $light-grey;
   padding-top: $gutter-width * 2;
 
@@ -9,18 +9,12 @@
     overflow: hidden;
     position: relative;
     height: 450px;
-    -moz-transition: left 1s;
-      -webkit-transition: left 1s;
-      -o-transition: left 1s;
     transition: left 1s;
   }
 
   .slide-container {
     position: absolute;
     width: (700 * 4)px;
-      -moz-transition: left 1s;
-      -webkit-transition: left 1s;
-      -o-transition: left 1s;
     transition: left 1s;
     left: 0;
   }

--- a/scss/patterns/_structure.scss
+++ b/scss/patterns/_structure.scss
@@ -7,12 +7,12 @@ header.banner .nav-primary,
 nav div.footer-a div,
 .inline-lists ul,
 .legal {
-	@include box-sizing();
+	box-sizing: border-box;
 	width: auto;
 }
 
 .inner-wrapper {
-	@include box-sizing();
+	box-sizing: border-box;
 	background: $white;
 	clear: both;
 	display: block;
@@ -48,7 +48,7 @@ nav div.footer-a div,
 @media only screen and (min-width: 984px) {
 
 	.wrapper {
-		@include box-sizing;
+		box-sizing: border-box;
 		background: $white;
 		margin: 0 auto;
 		position: relative;
@@ -57,7 +57,7 @@ nav div.footer-a div,
 	}
 
 	.inner-wrapper {
-		@include box-shadow(0 0 3px #c9c9c9);
+		box-shadow: 0 0 3px #c9c9c9;
 		margin: 10px 0 30px;
 	}
 

--- a/scss/patterns/_tabbed-content.scss
+++ b/scss/patterns/_tabbed-content.scss
@@ -1,7 +1,7 @@
 @charset 'UTF-8';
 
 html.js .tabbed-content .accordion-button {
-  @include box-sizing;
+  box-sizing: border-box;
   height: auto;
   padding-bottom: .6em;
   padding-right: 20px;
@@ -22,7 +22,7 @@ html.yui3-js-enabled {
   }
 
   .tabbed-content {
-			@include rounded-corners(4px);
+			border-radius: 4px;
 			padding: 8px 8px 0;
     	background: $light-grey;
       margin-bottom: 8px;
@@ -41,7 +41,7 @@ html.yui3-js-enabled {
       }
 
       .accordion-button {
-        @include box-sizing;
+        box-sizing: border-box;
         background: url("#{$asset-path}icons/icon-arrow-down.svg") no-repeat scroll right 3px $light-grey;
         color: $cool-grey;
         display: block;
@@ -128,16 +128,16 @@ html.yui3-js-enabled {
 @media only screen and (min-width : 768px) {
 
   .tabbed-menu {
-    @include box-shadow(0 -1px 10px #cfcfcf inset);
-    @include box-sizing;
-    @include rounded-corners(4px 4px 0 0);
+    box-shadow: 0 -1px 10px #cfcfcf inset;
+    box-sizing: border-box;
+    border-radius: 4px 4px 0 0;
     background: none repeat scroll 0 0 $light-grey;
     padding-bottom: $gutter-width;
     padding-top: $gutter-width;
     position: relative;
 
     ul {
-      @include box-sizing;
+      box-sizing: border-box;
       display: table;
       margin-bottom: 0;
       padding: 0;
@@ -192,7 +192,7 @@ html.yui3-js-enabled {
   }
 
   .tabbed-content-bg {
-    @include box-sizing;
+    box-sizing: border-box;
     background: $white;
     margin-left: 20px;
     margin-right: 20px;

--- a/scss/patterns/_tooltips.scss
+++ b/scss/patterns/_tooltips.scss
@@ -5,10 +5,8 @@
 }
 
 .yui3-tooltip-content {
-  @include box-shadow(0 2px 8px hsla(0, 0%, 0%, .20));
+  box-shadow: 0 2px 8px hsla(0, 0%, 0%, .20);
   background: url("#{$asset-path}patterns/grey-textured-background.jpg") repeat scroll 0 0 transparent;
-  -moz-border-radius: 4px;
-  -webkit-border-radius: 4px;
   border-radius: 4px;
   border: 1px solid #e3e3e3;
   color: $cool-grey;
@@ -77,8 +75,8 @@
 }
 
 .tooltip-label {
-  @include box-shadow(3px 3px 6px rgba(0, 0, 0, .3));
-  @include rounded-corners(4px);
+  box-shadow: 3px 3px 6px rgba(0, 0, 0, .3);
+  border-radius: 4px;
   background: $white;
   border: 1px solid #dfdcd9;
   display: none;


### PR DESCRIPTION
===

Remove any mixins and other mentions of vendor prefixes, 
to make sasslint happier.

Vendor prefixes are now taken care of by [autoprefixer](https://github.com/postcss/autoprefixer).

Done
---

- Rename `lint.yml` to the default `.scss-lint.yml` so it doesn't need specifying in `gulpfile.js` any more
- Remove mixins:
  * box-shadow
  * gradient
  * columns
  * transition
  * box-sizing
  * rounded-corners
  * background-size
- Remove mentions of these mixins from scss files
- Remove other references to vendor prefixes

QA
---

- Make sure sass still compiles
- Check sasslint doesn't spit out any "VendorPrefix" errors
- Extra credits: Check styles still seem to look right