### PR TITLE
Convert tabs to 2 spaces in scss files

### DIFF
--- a/scss/patterns/_blockquotes.scss
+++ b/scss/patterns/_blockquotes.scss
@@ -8,7 +8,7 @@ blockquote {
       color: $cool-grey;
       padding-left: 10px;
       padding-right: 10px;
-			@include font-size (24.833);
+      @include font-size (24.833);
       text-indent: -.4em;
       margin-left: .4em;
       line-height: 1.3;
@@ -21,14 +21,14 @@ blockquote {
         left: -5px;
 
         & + span { left: 5px; } // the second span
-			}
+      }
 
       cite {
         margin: 10px 0 0;
         font-weight: 300;
         display: block;
         font-size: .75em;
-				text-indent: 0;
+        text-indent: 0;
       }
     }
 
@@ -133,7 +133,7 @@ html.no-svg,
       color: $cool-grey;
       padding-left: 10px;
       padding-right: 10px;
-			//@include font-size (23);
+      //@include font-size (23);
       //font-size: 1em;
       text-indent: 0;
     }
@@ -203,8 +203,8 @@ blockquote.quote-canonical-white {
     @include font-size (24.83);
   }
 
- 	blockquote.pull-quote p,
- 	.row-quote blockquote p {
+   blockquote.pull-quote p,
+   .row-quote blockquote p {
     padding-left: 0;
     padding-right: 0;
     text-indent: -.7em;
@@ -230,7 +230,7 @@ blockquote.quote-canonical-white {
 
   .row-quote blockquote {
     p {
-			@include font-size (24.83);
+      @include font-size (24.83);
       text-indent: -.4em;
     }
   }
@@ -242,12 +242,11 @@ blockquote.quote-canonical-white {
   .row-quote blockquote {
     padding: 0 80px 20px;
     text-indent: -10px;
-	}
+  }
 
-	blockquote.pull-quote p span,
-	.row-quote blockquote p span {
-		top: 10px;
-	}
+  blockquote.pull-quote p span,
+  .row-quote blockquote p span {
+    top: 10px;
+  }
 
 } // end @media only screen and (min-width: 984px)
-

--- a/scss/patterns/_boxes.scss
+++ b/scss/patterns/_boxes.scss
@@ -23,8 +23,8 @@
 }
 
 .box-highlight {
-	box-shadow: 0 2px 2px 0 #c2c2c2;
-	border: 1px solid $light-grey;
+  box-shadow: 0 2px 2px 0 #c2c2c2;
+  border: 1px solid $light-grey;
 }
 
 .box-textured {
@@ -47,8 +47,8 @@
   }
 
   li h3 { // this happens in 'Further reading' /cloud/insights
-	  @include font-size(19.5);
-	  margin: 0;
+    @include font-size(19.5);
+    margin: 0;
   }
 
   div {
@@ -88,18 +88,18 @@
     margin-bottom: 0;
   }
 
-	.inline-icons {
-		display: table;
-		width: 100%;
-		margin: 0;
-		text-align: center;
+  .inline-icons {
+    display: table;
+    width: 100%;
+    margin: 0;
+    text-align: center;
 
     li {
       display: table-cell;
       text-align: left;
       float: none;
     }
-	}
+  }
 
   .one-col {
     width: 48px;
@@ -237,4 +237,3 @@ html.yui3-js-enabled .resource:hover a {
 @media only screen and (min-width: 984px) {
 
 } // end @media only screen and (min-width: 984px)
-

--- a/scss/patterns/_buttons.scss
+++ b/scss/patterns/_buttons.scss
@@ -7,40 +7,40 @@ button.cta-ubuntu,
 button.cta-canonical,
 form button[type="submit"],
 form input[type="submit"] {
-	box-sizing: border-box;
-	@include font-size (16);
-	border-radius: 3px;
-	background: $ubuntu-orange;
-	color: $white;
-	text-decoration: none;
-	display: inline-block;
-	margin: 0;
-	font-family: Ubuntu, Arial, 'libra sans', sans-serif;
-	font-weight: 300;
-	font-smoothing: subpixel-antialiased;
-	padding: 8px 14px;
-	width: 100%;
-	text-align: center;
+  box-sizing: border-box;
+  @include font-size (16);
+  border-radius: 3px;
+  background: $ubuntu-orange;
+  color: $white;
+  text-decoration: none;
+  display: inline-block;
+  margin: 0;
+  font-family: Ubuntu, Arial, 'libra sans', sans-serif;
+  font-weight: 300;
+  font-smoothing: subpixel-antialiased;
+  padding: 8px 14px;
+  width: 100%;
+  text-align: center;
 }
 
 a.cta-large,
 button.cta-large {
-	@include font-size (18);
-	padding: 10px 20px;
+  @include font-size (18);
+  padding: 10px 20px;
 }
 
 a.link-cta-canonical,
 button.cta-canonical,
 form button.cta-canonical[type="submit"],
 form input.cta-canonical[type="submit"] {
-	background: $canonical-aubergine;
-	color: $white;
+  background: $canonical-aubergine;
+  color: $white;
 }
 
 a.link-cta-inverted,
 button.cta-inverted {
-	background: $white;
-	color: $cool-grey;
+  background: $white;
+  color: $cool-grey;
 }
 
 .row-enterprise a.link-cta-canonical,
@@ -54,13 +54,13 @@ a.link-cta-ubuntu:hover,
 button.cta-ubuntu:hover,
 form button[type="submit"]:hover,
 form input[type="submit"]:hover {
-	background: darken($ubuntu_orange, 6.2%); // #c03f11
-	text-decoration: none;
+  background: darken($ubuntu_orange, 6.2%); // #c03f11
+  text-decoration: none;
 }
 
 a.link-cta-canonical:hover,
 button.cta-canonical:hover {
-	background: darken($canonical-aubergine, 6.2%); // #5f193e
+  background: darken($canonical-aubergine, 6.2%); // #5f193e
   text-decoration: none;
 }
 
@@ -83,15 +83,15 @@ button.cta-deactivated:hover {
 
 @media only screen and (min-width : 768px) {
 
-	a.link-cta-ubuntu,
-	a.link-cta-canonical,
-	a.link-cta-inverted,
-	button.cta-ubuntu,
-	button.cta-canonical,
-	form button[type="submit"],
-	form input[type="submit"] {
-	  width: auto;
-	}
+  a.link-cta-ubuntu,
+  a.link-cta-canonical,
+  a.link-cta-inverted,
+  button.cta-ubuntu,
+  button.cta-canonical,
+  form button[type="submit"],
+  form input[type="submit"] {
+    width: auto;
+  }
 
 } // end @media only screen and (max-width : 768px)
 
@@ -100,14 +100,14 @@ button.cta-deactivated:hover {
 
 @media only screen and (min-width: 984px) {
 
-	a.link-cta-ubuntu,
-	a.link-cta-canonical,
-	a.link-cta-inverted,
-	button.cta-ubuntu,
-	button.cta-canonical,
-	form button[type="submit"],
-	form input[type="submit"] {
-	  width: auto;
-	}
+  a.link-cta-ubuntu,
+  a.link-cta-canonical,
+  a.link-cta-inverted,
+  button.cta-ubuntu,
+  button.cta-canonical,
+  form button[type="submit"],
+  form input[type="submit"] {
+    width: auto;
+  }
 
 } // end @media only screen and (min-width: 984px)

--- a/scss/patterns/_contextual-footer.scss
+++ b/scss/patterns/_contextual-footer.scss
@@ -1,82 +1,82 @@
 @charset 'UTF-8';
 
 #context-footer {
-	box-sizing: border-box;
-	@include font-size (14);
-	border-bottom: 0;
-	clear: both;
-	padding-bottom: 1px;
-	padding-top: 0;
-	position: relative;
-	margin-bottom: 0;
-	margin-left: 0;
-	margin-right: 0;
-	width: 100%;
+  box-sizing: border-box;
+  @include font-size (14);
+  border-bottom: 0;
+  clear: both;
+  padding-bottom: 1px;
+  padding-top: 0;
+  position: relative;
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-right: 0;
+  width: 100%;
 
-	hr {
-		box-shadow: inset 0 2px 2px -2px #333;
-		background: $ubuntu-orange;
-		height: 14px;
-		margin: 0 0 10px;
-		border: 0;
-		clear: both;
-	}
+  hr {
+    box-shadow: inset 0 2px 2px -2px #333;
+    background: $ubuntu-orange;
+    height: 14px;
+    margin: 0 0 10px;
+    border: 0;
+    clear: both;
+  }
 
-	div.twelve-col {
-		display: table;
-		float: none;
-		margin-bottom: 7px;
-	}
+  div.twelve-col {
+    display: table;
+    float: none;
+    margin-bottom: 7px;
+  }
 
-	div div {
-		display: block;
-		padding-left: 0;
-		margin-bottom: 20px;
+  div div {
+    display: block;
+    padding-left: 0;
+    margin-bottom: 20px;
 
-		div {
-			display: block;
-			padding-left: 0;
-			margin-bottom: 0;
-		}
+    div {
+      display: block;
+      padding-left: 0;
+      margin-bottom: 0;
+    }
 
-		&.feature-one {
-			padding-left: 0;
-		}
+    &.feature-one {
+      padding-left: 0;
+    }
 
-		&.feature-four {
-			margin-bottom: 0;
-			margin-right: 0;
-		}
-	}
+    &.feature-four {
+      margin-bottom: 0;
+      margin-right: 0;
+    }
+  }
 
-	> div {
-	  padding-left: 10px;
-	  padding-right: 10px;
-	}
+  > div {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
 
-	ul {
-		margin-bottom: 5px;
-	}
+  ul {
+    margin-bottom: 5px;
+  }
 
-	li.active {
-		display: none;
-	}
+  li.active {
+    display: none;
+  }
 
-	h3 {
-		@include font-size (16);
-		font-weight: normal;
-	}
+  h3 {
+    @include font-size (16);
+    font-weight: normal;
+  }
 
-	.list a:after,
-	a.link-arrow:after,
-	nav ul li h2 a:after {
-		content: ' \203A';
-	}
+  .list a:after,
+  a.link-arrow:after,
+  nav ul li h2 a:after {
+    content: ' \203A';
+  }
 }
 
 @media only screen and (min-width : 768px) {
 
-	#context-footer {
+  #context-footer {
     margin-bottom: 12px;
     padding-left: 30px;
     padding-right: 30px;
@@ -107,20 +107,20 @@
 
 @media only screen and (min-width: 984px) {
 
-	#context-footer {
-		padding: 0 40px 10px;
-	}
+  #context-footer {
+    padding: 0 40px 10px;
+  }
 
-	#context-footer div div {
-		display: table-cell;
-		float: none;
-		padding-left: 20px;
-		margin-bottom: 0;
-	}
+  #context-footer div div {
+    display: table-cell;
+    float: none;
+    padding-left: 20px;
+    margin-bottom: 0;
+  }
 
-	#context-footer hr {
-		margin: 0 -40px 40px;
-	}
+  #context-footer hr {
+    margin: 0 -40px 40px;
+  }
 
 
 } // end @media only screen and (min-width: 984px)

--- a/scss/patterns/_footer.scss
+++ b/scss/patterns/_footer.scss
@@ -1,103 +1,103 @@
 @charset "UTF-8";
 
 body footer.global #nav-global li:first-of-type a {
-	margin-left: 0;
+  margin-left: 0;
 }
 
 footer.global {
-	box-sizing: border-box;
-	box-shadow: inset 0 2px 2px -1px #d3d3d3;
-	background: none;
-	border-top: 0;
-	clear: both;
-	display: block;
-	padding: 30px 10px 20px;
-	position: relative;
-	width: 100%;
+  box-sizing: border-box;
+  box-shadow: inset 0 2px 2px -1px #d3d3d3;
+  background: none;
+  border-top: 0;
+  clear: both;
+  display: block;
+  padding: 30px 10px 20px;
+  position: relative;
+  width: 100%;
 
 
-	.legal {
-		/* Can be removed once live */
-		margin: 0 auto;
-		width: 100%; /* 980px / 15px (baseline font); 980px + (60px x 2) = 1100px */
-	}
+  .legal {
+    /* Can be removed once live */
+    margin: 0 auto;
+    width: 100%; /* 980px / 15px (baseline font); 980px + (60px x 2) = 1100px */
+  }
 
-	.legal {
-		background-image: none;
-		position: relative;
-		clear: both;
-		min-height: 40px;
+  .legal {
+    background-image: none;
+    position: relative;
+    clear: both;
+    min-height: 40px;
 
-		p,
-		ul {
-			padding-left: 0;
-		}
-	} // legal
+    p,
+    ul {
+      padding-left: 0;
+    }
+  } // legal
 
-	h2 {
-	  font-size: 0.75em;
-		line-height: 1.4;
-	  margin-bottom: 0;
-	  padding-bottom: 0.5em;
-	}
+  h2 {
+    font-size: 0.75em;
+    line-height: 1.4;
+    margin-bottom: 0;
+    padding-bottom: 0.5em;
+  }
 
-	h2, h2 a:link, h2 a:visited {
-		color: $cool-grey;
-	  font-weight: normal;
-	}
+  h2, h2 a:link, h2 a:visited {
+    color: $cool-grey;
+    font-weight: normal;
+  }
 
-	nav ul li h2 a:after { content: ""; }
+  nav ul li h2 a:after { content: ""; }
 
-	ul {	margin: 0; }
+  ul {  margin: 0; }
 
-	nav ul li.two-col {
-		display: inline-block;
-		min-height: 10em;
-		vertical-align: top;
-	}
+  nav ul li.two-col {
+    display: inline-block;
+    min-height: 10em;
+    vertical-align: top;
+  }
 
-	nav ul li li {
-	  @include font-size (12);
-	  font-size: 0.75em;
-		margin-bottom: 0;
-	}
+  nav ul li li {
+    @include font-size (12);
+    font-size: 0.75em;
+    margin-bottom: 0;
+  }
 
-	ul li li a:link, ul li li a:visited {
-		color: $cool-grey;
-		margin-bottom: 0;
-	}
+  ul li li a:link, ul li li a:visited {
+    color: $cool-grey;
+    margin-bottom: 0;
+  }
 
-	ul li li a:hover, ul li li a:active, h2 a:hover, h2 a:active {
-		color: $ubuntu-orange;
-		//text-decoration: underline;
-	}
+  ul li li a:hover, ul li li a:active, h2 a:hover, h2 a:active {
+    color: $ubuntu-orange;
+    //text-decoration: underline;
+  }
 
-	.inline li { display: inline; }
+  .inline li { display: inline; }
 
-	p, ul.inline li a {
-		color: $cool-grey;
-		font-size: 12px;
-		margin-bottom: 0;
-	}
-	ul.inline li a:hover { color: $ubuntu-orange; }
-	
-	ul.inline li:after {
-		color: $warm-grey;
-		content: "\00b7";
-		vertical-align: middle;
-		margin: 0 5px;
-	}
-	
-	ul.inline li:last-child { width: 120px; }
-	
-	ul.inline li:last-child:after { content: ""; }
-	
-	.inline li {
-	    float: none;
-	    margin-bottom: 0;
-	}
+  p, ul.inline li a {
+    color: $cool-grey;
+    font-size: 12px;
+    margin-bottom: 0;
+  }
+  ul.inline li a:hover { color: $ubuntu-orange; }
+  
+  ul.inline li:after {
+    color: $warm-grey;
+    content: "\00b7";
+    vertical-align: middle;
+    margin: 0 5px;
+  }
+  
+  ul.inline li:last-child { width: 120px; }
+  
+  ul.inline li:last-child:after { content: ""; }
+  
+  .inline li {
+      float: none;
+      margin-bottom: 0;
+  }
 
-	.top-link {
+  .top-link {
     box-shadow: 0 -4px 4px -4px rgba(0, 0, 0, 0.3) inset;
     background: none repeat scroll 0 0 rgba(0, 0, 0, 0);
     border: 0 none;
@@ -122,7 +122,7 @@ footer.global {
       font-weight: 400;
       padding: 12px 0 12px 28px;
     }
-	}
+  }
 } /* End footer.global */
 
 html.no-svg, .opera-mini {
@@ -135,14 +135,14 @@ html.no-svg, .opera-mini {
 
 
 @media only screen and (max-width : 768px) {
-	footer.no-global .legal {
+  footer.no-global .legal {
         box-sizing: content-box;
-		box-shadow: 0 2px 2px -1px #D3D3D3 inset;
-		padding-top: 10px;
-		margin-left: -10px;
-		padding-left: 10px;
-		padding-right: 10px;
-	}
+    box-shadow: 0 2px 2px -1px #D3D3D3 inset;
+    padding-top: 10px;
+    margin-left: -10px;
+    padding-left: 10px;
+    padding-right: 10px;
+  }
 
   #livechat-eye-catcher {
     display: block;
@@ -152,10 +152,10 @@ html.no-svg, .opera-mini {
 
 @media only screen and (min-width : 768px) {
 
-	footer.global .inline li {
-	    display: inline;
-	    float: left;
-	}
+  footer.global .inline li {
+      display: inline;
+      float: left;
+  }
 
 } // @media only screen and (min-width : 768px)
 
@@ -166,7 +166,7 @@ html.no-svg, .opera-mini {
   }
 
   footer.global .footer-b h2 a i {
-		font-style: normal;
+    font-style: normal;
     display: inline;
   }
 
@@ -174,23 +174,22 @@ html.no-svg, .opera-mini {
 
 @media only screen and (min-width: 984px) {
 
-	footer.global .legal {
-		width: 984px; /* 980px / 15px (baseline font); 980px + (60px x 2) = 1100px */
-	}
+  footer.global .legal {
+    width: 984px; /* 980px / 15px (baseline font); 980px + (60px x 2) = 1100px */
+  }
 
-	footer.global {
-		padding: 30px 0 20px;
-		
-		.legal {
-			background: url("#{$asset-path}logos/logo-ubuntu-grey.png") 100% 0 no-repeat;
-		}
+  footer.global {
+    padding: 30px 0 20px;
+    
+    .legal {
+      background: url("#{$asset-path}logos/logo-ubuntu-grey.png") 100% 0 no-repeat;
+    }
 
-		.footer-a {
-			display: block;
-		}
-	}
+    .footer-a {
+      display: block;
+    }
+  }
 
 
 
 } // end @media only screen and (min-width: 984px)
-

--- a/scss/patterns/_forms.scss
+++ b/scss/patterns/_forms.scss
@@ -1,29 +1,29 @@
 @charset 'UTF-8';
 
 form {
-	input,
-	select,
-	textarea {
-		box-sizing: border-box;
-		width: 100%;
-	}
+  input,
+  select,
+  textarea {
+    box-sizing: border-box;
+    width: 100%;
+  }
 
-	.fieldset-submit ul {
-	  margin-bottom: 0;
-	}
+  .fieldset-submit ul {
+    margin-bottom: 0;
+  }
 
-	fieldset {
-		.mktError,
-		.errMsg,
-		.reqMark {
-			color: $error;
-		}
+  fieldset {
+    .mktError,
+    .errMsg,
+    .reqMark {
+      color: $error;
+    }
 
-		.mktFormMsg {
-			clear: both;
-			display: block;
-		}
-	}
+    .mktFormMsg {
+      clear: both;
+      display: block;
+    }
+  }
 }
 
 @media only screen and (max-width : 768px) {

--- a/scss/patterns/_header.scss
+++ b/scss/patterns/_header.scss
@@ -1,64 +1,64 @@
 @charset "UTF-8";
 
 header.banner {
-	border-top: 0;
-	min-width: 100%;
-	width: auto;
+  border-top: 0;
+  min-width: 100%;
+  width: auto;
   background: $ubuntu-orange;
   display: block;
   position: relative;
   z-index: 2;
 
-	.nav-primary {
-	  border: 0;
-		margin: 0 auto;
-		overflow: hidden;
+  .nav-primary {
+    border: 0;
+    margin: 0 auto;
+    overflow: hidden;
 
-		ul {
-		  border-right: 1px solid lighten($ubuntu-orange, 10%);
-		  float: left;
-		  margin: 0;
-		  position: relative;
+    ul {
+      border-right: 1px solid lighten($ubuntu-orange, 10%);
+      float: left;
+      margin: 0;
+      position: relative;
 
-			li {
-			  border-left: 1px solid darken($ubuntu-orange, 5%);
-			  float: left;
-			  list-style-image: none;
-			  margin: 0;
-			  text-indent: 0;
-			  vertical-align: bottom;
-			}
+      li {
+        border-left: 1px solid darken($ubuntu-orange, 5%);
+        float: left;
+        list-style-image: none;
+        margin: 0;
+        text-indent: 0;
+        vertical-align: bottom;
+      }
 
-			li:last-child {
-			  border-right: 1px solid darken($ubuntu-orange, 5%);
-			}
+      li:last-child {
+        border-right: 1px solid darken($ubuntu-orange, 5%);
+      }
 
-			li a:link,
-			li a:visited {
-			  font-size: 14px;
-			  border-left: 1px solid lighten($ubuntu-orange, 7%);
-			  color: $white;
-			  display: block;
-			  margin-bottom: 0;
-			  padding: 14px 14px 13px;
-			  position: relative;
-			  text-align: center;
-			  text-decoration: none;
-			  font-smoothing: subpixel-antialiased;
-			}
+      li a:link,
+      li a:visited {
+        font-size: 14px;
+        border-left: 1px solid lighten($ubuntu-orange, 7%);
+        color: $white;
+        display: block;
+        margin-bottom: 0;
+        padding: 14px 14px 13px;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        font-smoothing: subpixel-antialiased;
+      }
 
-			a.active {
-			  background: #B83A10;
-			  border-left: 1px solid lighten($ubuntu-orange, 7%);
-			}
+      a.active {
+        background: #B83A10;
+        border-left: 1px solid lighten($ubuntu-orange, 7%);
+      }
 
-			li a:hover {
-				background: #e1662f;
-				border-top: 0;
-				box-shadow: inset 0 2px 2px -2px #777;
-			}
-		} // end ul
-	} // nav-primary
+      li a:hover {
+        background: #e1662f;
+        border-top: 0;
+        box-shadow: inset 0 2px 2px -2px #777;
+      }
+    } // end ul
+  } // nav-primary
 
 } // end header.banner
 
@@ -67,80 +67,80 @@ header.banner {
 #main-navigation-link { display: none; }
 
 header.banner .nav-toggle {
-	position:absolute;
-	right: 0;
-	display: block;
-	width: 48px;
-	height: 48px;
-	text-indent: -99999px;
-	background-image: url(#{$asset-path}icons/navigation-menu-plain.svg);
-	background-size: 25px auto;
-	background-repeat: no-repeat;
-	background-position: center center;
-	cursor: pointer;
+  position:absolute;
+  right: 0;
+  display: block;
+  width: 48px;
+  height: 48px;
+  text-indent: -99999px;
+  background-image: url(#{$asset-path}icons/navigation-menu-plain.svg);
+  background-size: 25px auto;
+  background-repeat: no-repeat;
+  background-position: center center;
+  cursor: pointer;
 }
 
 header.banner .no-script {
-	display: none;
+  display: none;
 }
 
 .opera-mini header.banner .nav-toggle,
 .no-svg header.banner .nav-toggle {
-	background-image: url(#{$asset-path}icons/navigation-menu-plain.png);
+  background-image: url(#{$asset-path}icons/navigation-menu-plain.png);
 }
 
 header.banner nav ul {
-	background-color: $nav-bg;
-	display: none;
-	float: left;
+  background-color: $nav-bg;
+  display: none;
+  float: left;
 }
 header.banner .nav-primary.active {
-	box-shadow: 0 1px 2px 1px rgba(120, 120, 120, 0.2);
-	padding: 0;
-	border-bottom: 1px solid $nav-border-dark;
+  box-shadow: 0 1px 2px 1px rgba(120, 120, 120, 0.2);
+  padding: 0;
+  border-bottom: 1px solid $nav-border-dark;
 }
 
 header nav ul.active {
-	display: block;
+  display: block;
 }
 
 header.banner .nav-primary ul li,
 header.banner .nav-primary ul li a:link,
 header.banner .nav-primary ul li a:visited,
 header.banner .nav-primary ul li a:active {
-	display: block;
-	padding: 0;
-	margin: 0;
-	border: none;
+  display: block;
+  padding: 0;
+  margin: 0;
+  border: none;
 }
 
 header.banner .nav-primary ul li a:hover {
-	box-shadow: none;
-	background-color: $nav-hover-bg;
+  box-shadow: none;
+  background-color: $nav-hover-bg;
 }
 header.banner .nav-primary ul li a.active {
-	background-color: $nav-active-bg;
+  background-color: $nav-active-bg;
 }
 
 header.banner .nav-primary ul li {
-	border-bottom: 1px solid #F2F2F4;
-	font-size: 16px;
+  border-bottom: 1px solid #F2F2F4;
+  font-size: 16px;
 }
 
 header.banner .nav-primary ul li:last-child {
-	border: 0;
+  border: 0;
 }
 
 header.banner nav.nav-primary ul li a:link,
 header.banner .nav-primary ul li a:visited,
 header.banner .nav-primary ul li a:hover,
 header.banner .nav-primary ul li a:active {
-	padding: 14px 14px 13px;
-	text-align: left;
+  padding: 14px 14px 13px;
+  text-align: left;
 }
 
 header.banner nav.nav-primary ul.active li ul {
-	display: none;
+  display: none;
 }
 
 #menu.active:after {
@@ -178,7 +178,7 @@ html.no-svg, .opera-mini {
       float: left;
       margin-top: 16px;
       font-size: 14px;
-	    margin-right: 15px;
+      margin-right: 15px;
 
       a:link,
       a:visited {
@@ -219,31 +219,31 @@ html.no-svg, .opera-mini {
 }
 
 header.banner h2 {
-	@include font-size (25);
-	display: block;
-	left: 4px;
-	margin-bottom:0;
-	position: relative;
-	text-transform: lowercase;
-	top: 14px;
+  @include font-size (25);
+  display: block;
+  left: 4px;
+  margin-bottom:0;
+  position: relative;
+  text-transform: lowercase;
+  top: 14px;
 }
 
 header.banner h2 a:link, header.banner h2 a:visited, header.banner a {
-	color: $white;
-	float: left;
-	text-decoration:none;
+  color: $white;
+  float: left;
+  text-decoration:none;
 }
 
 header.banner {
-	.logo {
-	  border-left: 0;
-  	float: left;
+  .logo {
+    border-left: 0;
+    float: left;
     height: 48px;
-  	overflow: hidden;
-	}
+    overflow: hidden;
+  }
 
   .logo-ubuntu {
-  	background: url("#{$asset-path}ubuntu-logo.png") no-repeat scroll 0 10px transparent;
+    background: url("#{$asset-path}ubuntu-logo.png") no-repeat scroll 0 10px transparent;
     font-size: 18px;
     margin-bottom: 0;
     position: relative;
@@ -254,7 +254,7 @@ header.banner {
     height: 32px;
     min-width: 128px;
     margin-right: -20px;
-		margin-left: 10px;
+    margin-left: 10px;
     padding: 7px 14px 9px 0;
 
     img {
@@ -281,8 +281,8 @@ header.banner {
   }
   .nav-primary.nav-right {
     .logo-ubuntu {
-			background-image: url("#{$asset-path}logos/logo-ubuntu-white.svg");
-			background-size: 107px 25px;
+      background-image: url("#{$asset-path}logos/logo-ubuntu-white.svg");
+      background-size: 107px 25px;
       float: left;
     }
   }
@@ -297,24 +297,24 @@ html.no-svg, .opera-mini {
 @media only screen and (max-width: 295px) {
 
 // this changes the logo to the circle of friends on screens below 295px
-	header.banner {
-		.nav-primary.nav-right .logo-ubuntu,
-		.logo-ubuntu {
-			background-size: 20px 20px;
-			background: url('#{$asset-path}logos/logo-ubuntu_cof-white_orange-hex.svg') 0 50% no-repeat;
-			min-width: 0;
-			width: 38px;
-		}
-	}
-	header.banner .logo-ubuntu span {
-		padding-left: 38px;
-	}
-	
+  header.banner {
+    .nav-primary.nav-right .logo-ubuntu,
+    .logo-ubuntu {
+      background-size: 20px 20px;
+      background: url('#{$asset-path}logos/logo-ubuntu_cof-white_orange-hex.svg') 0 50% no-repeat;
+      min-width: 0;
+      width: 38px;
+    }
+  }
+  header.banner .logo-ubuntu span {
+    padding-left: 38px;
+  }
+  
 } // end @@media only screen and (max-width: 295px)
 
 html.no-svg, .opera-mini {
   header.banner .logo-ubuntu {
-		background-image: url('#{$asset-path}logos/logo-ubuntu_cof-white_orange-hex.png');
+    background-image: url('#{$asset-path}logos/logo-ubuntu_cof-white_orange-hex.png');
   }
 }
 
@@ -334,9 +334,9 @@ html.no-svg, .opera-mini {
   
   header nav ul.active li:last-child a:link,
   header nav ul.active li:last-child a:visited {
-		border-bottom: 0;
-	}
-	  
+    border-bottom: 0;
+  }
+    
   header.banner .nav-primary ul {
     position: relative;
     width: 100%;
@@ -376,12 +376,12 @@ html.no-svg, .opera-mini {
   
   header.banner .nav-primary ul li:nth-last-child(-n+2) a:link,
   header.banner .nav-primary ul li:nth-last-child(-n+2) a:visited  {
-		border: 0;
-	}	
+    border: 0;
+  }  
 
   header.banner .nav-primary ul li a:hover {
     box-shadow: none;
-  	background: lighten($nav_bg, 3%);
+    background: lighten($nav_bg, 3%);
   }
   header.banner .nav-primary ul li a.active {
     background-color: $nav-active-bg;
@@ -692,7 +692,7 @@ html.no-svg, .opera-mini {
 
     nav.nav-primary {
       box-shadow: none;
-			border-bottom: 0;
+      border-bottom: 0;
 
     }
   }
@@ -767,7 +767,7 @@ html.no-svg, .opera-mini {
   }
 
   header.banner nav.nav-primary ul {
-		display: block;
+    display: block;
   }
 
   header.banner .nav-primary,
@@ -788,36 +788,36 @@ html.no-svg, .opera-mini {
 header.banner .nav-primary ul { position: static; }
 
 header.banner .nav-primary li ul {
-	box-shadow: 0 2px 2px -1px #777777;
-	border-radius: 10px;
-	background: #f7f7f7;
-	border: 1px solid #d5d5d5;
-	display: none;
-	float: none;
-	margin: 0;
-	padding: 5px 0;
-	position: absolute;
-	top: 51px;
-	width: 200px;
+  box-shadow: 0 2px 2px -1px #777777;
+  border-radius: 10px;
+  background: #f7f7f7;
+  border: 1px solid #d5d5d5;
+  display: none;
+  float: none;
+  margin: 0;
+  padding: 5px 0;
+  position: absolute;
+  top: 51px;
+  width: 200px;
 }
 
 // the new arrow that appears if there is secondary nav when you hover over the main nav
 header.banner .nav-primary li:hover ul:after {
-	background: url("#{$asset-path}patterns/arrow-up-smaller.png") no-repeat;
-	content: '';
-	display: block;
-	height: 8px;
-	left: 20px;
-	position: relative;
-	top: -13px;
-	width: 200px;
-	z-index: 999;
+  background: url("#{$asset-path}patterns/arrow-up-smaller.png") no-repeat;
+  content: '';
+  display: block;
+  height: 8px;
+  left: 20px;
+  position: relative;
+  top: -13px;
+  width: 200px;
+  z-index: 999;
 }
 
 // show secondary nav differently if :after isn't supported, remove arrow and move secondary nav up to meet the bottom of the navbar
 .no-generatedcontent header.banner .nav-primary li ul {
-	border-radius: 0 0 10px 10px;
-	top: 48px;
+  border-radius: 0 0 10px 10px;
+  top: 48px;
 }
 
 // the old arrow that appears if there is secondary nav when you hover over the main nav
@@ -888,4 +888,3 @@ header.banner .nav-primary li ul .promo .category {
 header.banner .nav-primary li:hover ul { display: block; }
 
 html.lt-ie8 header.banner .nav-primary li:hover ul { display: none; }
-

--- a/scss/patterns/_helpers.scss
+++ b/scss/patterns/_helpers.scss
@@ -9,9 +9,9 @@
 .caps { text-transform: uppercase; }
 
 img {
-	border: 0 none;
-	height: auto;
-	max-width: 100%;
+  border: 0 none;
+  height: auto;
+  max-width: 100%;
 
   &.left { margin-right: 0; }
 
@@ -20,8 +20,8 @@ img {
 
 .accessibility-aid,
 .off-left {
-	position: absolute;
-	left: -999em;
+  position: absolute;
+  left: -999em;
 }
 
 
@@ -71,10 +71,10 @@ a.external {
 }
 
 .pull-bottom-right {
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	left: auto;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: auto;
 }
 
 .box .pull-bottom-right {
@@ -149,17 +149,17 @@ img {
     }
   }
 
-	.priority-0,
-	.not-for-small {
+  .priority-0,
+  .not-for-small {
     position: relative;
     left: auto;
-	}
+  }
 
-	.for-mobile,
+  .for-mobile,
   .for-small {
     position: absolute;
     left: -999em;
-	}
+  }
 
   .pull-right {
     float: right;
@@ -170,7 +170,7 @@ img {
     margin-left: -30px;
   }
 
-	img.touch-border {
+  img.touch-border {
     float: left;
     margin-bottom: -30px;
   }
@@ -190,23 +190,20 @@ img {
     margin-bottom: -40px;
   }
 
-	img.pull-left { margin-left: -40px; }
+  img.pull-left { margin-left: -40px; }
 
   .pull-right {
     float: right;
     margin-right: -40px;
   }
 
-	.for-tablet,
+  .for-tablet,
   .for-medium {
     display: none;
   }
 
-	.no-border {
-		border: 0;
-	}
+  .no-border {
+    border: 0;
+  }
 
 } // end @media only screen and (min-width: 984px)
-
-
-

--- a/scss/patterns/_image-centered.scss
+++ b/scss/patterns/_image-centered.scss
@@ -4,184 +4,184 @@
 div.box-image-centered,
 div.row-image-centered,
 div.row.row-image-centered {
-	padding: 20px 10px 0;
+  padding: 20px 10px 0;
 }
 
 .row-box.row-image-centered {
-	padding-top: 20px;
-	padding-bottom: 20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
 }
 
 .row.row-image-centered {
   padding-top: 40px;
-	padding-bottom: 40px;
+  padding-bottom: 40px;
 }
 
 .row-hero.row-image-centered {
-		padding-top: 0;
+    padding-top: 0;
 }
 
 div.row-image-centered,
 div.box-image-centered,
 div.row.row-image-centered {
-	//display: block;
+  //display: block;
 
-	div,
-	span {
-		//display: block;
-		float: none;
-	}
+  div,
+  span {
+    //display: block;
+    float: none;
+  }
 
-	span {
-		width: 100%;
+  span {
+    width: 100%;
 
-		img {
-			height: auto;
-			max-width: 100%;
-			display: block;
-			padding: 0;
-			margin: 0 auto;
-			margin-bottom: 20px;
-		}
-	}
+    img {
+      height: auto;
+      max-width: 100%;
+      display: block;
+      padding: 0;
+      margin: 0 auto;
+      margin-bottom: 20px;
+    }
+  }
 
-	p,
-	h2,
-	h3 {
-		float: none;
-	}
+  p,
+  h2,
+  h3 {
+    float: none;
+  }
 }
 
 @media only screen and (min-width : 768px) {
 
-	div.row-image-centered,
-	div.row.row-image-centered,
-	div.box-image-centered {
-		box-sizing: border-box;
-		padding-bottom: 20px;
-		display: table;
+  div.row-image-centered,
+  div.row.row-image-centered,
+  div.box-image-centered {
+    box-sizing: border-box;
+    padding-bottom: 20px;
+    display: table;
 
-		div {
-			float: none;
-			display: table-cell;
-			position: relative;
+    div {
+      float: none;
+      display: table-cell;
+      position: relative;
 
-			p,
-			h2,
-			h3 {
-				display: block;
-				width: 100%;
-				float: left;
-			}
+      p,
+      h2,
+      h3 {
+        display: block;
+        width: 100%;
+        float: left;
+      }
 
-			+ span img { // if image is on the right hand side
-				padding-right: 0;
-				margin-bottom: 20px;
-			}
-		}
+      + span img { // if image is on the right hand side
+        padding-right: 0;
+        margin-bottom: 20px;
+      }
+    }
 
-		span {
-			display: table-cell;
-			float: none;
-			position: relative;
-			text-align: center;
-			top: 0;
-			vertical-align: middle;
-			width: auto;
+    span {
+      display: table-cell;
+      float: none;
+      position: relative;
+      text-align: center;
+      top: 0;
+      vertical-align: middle;
+      width: auto;
 
-			img {
-				padding-right: 20px; // if image is on the left hand side
-			}
-		}
-	}
-	/* 
-		alternative to row-image-centered
-		requires equal-height class on row 
-		add align-vertically to the div containing the image
-		http://caniuse.com/transforms2d
-	*/
-	.js .align-vertically {
-		transform-style: preserve-3d;
-		
-		img, 
-		div {
-		  -ms-transform: translateY(-50%); // for IE9
-		  -webkit-transform: translateY(-50%);
-		  position: relative;
-		  top: 50%;
-		  transform: translateY(-50%);
-		}
-	}
+      img {
+        padding-right: 20px; // if image is on the left hand side
+      }
+    }
+  }
+  /* 
+    alternative to row-image-centered
+    requires equal-height class on row 
+    add align-vertically to the div containing the image
+    http://caniuse.com/transforms2d
+  */
+  .js .align-vertically {
+    transform-style: preserve-3d;
+    
+    img, 
+    div {
+      -ms-transform: translateY(-50%); // for IE9
+      -webkit-transform: translateY(-50%);
+      position: relative;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
 } //@media only screen and (min-width : 768px)
 
 div.box-image-centered {
-	padding-top: 20px;
+  padding-top: 20px;
 }
 
 @media only screen and (min-width : 768px) {
 
-	.row.row-image-centered,
-	div.box-image-centered,
-	div.row-image-centered,
-	div.row.row-image-centered {
-	    padding: 30px;
-	}
-	
-	div.box-image-centered div + span img,
-	div.row-image-centered div + span img,
-	div.row.row-image-centered div + span img,
-	div.box-image-centered span img.priority-0,
-	div.row-image-centered span img.priority-0,
-	div.row.row-image-centered span img.priority-0 {
-		margin-right: auto;
-		display: table-cell;
-		margin-bottom: 0;
-	}
+  .row.row-image-centered,
+  div.box-image-centered,
+  div.row-image-centered,
+  div.row.row-image-centered {
+      padding: 30px;
+  }
+  
+  div.box-image-centered div + span img,
+  div.row-image-centered div + span img,
+  div.row.row-image-centered div + span img,
+  div.box-image-centered span img.priority-0,
+  div.row-image-centered span img.priority-0,
+  div.row.row-image-centered span img.priority-0 {
+    margin-right: auto;
+    display: table-cell;
+    margin-bottom: 0;
+  }
 
 } // @media only screen and (min-width : 768px)
 
 @media only screen and (min-width: 984px) {
 
   .row.row-image-centered,
-	div.row-image-centered,
-	div.row.row-image-centered,
-	div.box-image-centered {
-		box-sizing: border-box;
-		padding: 60px 40px 60px;
-		display: table;
+  div.row-image-centered,
+  div.row.row-image-centered,
+  div.box-image-centered {
+    box-sizing: border-box;
+    padding: 60px 40px 60px;
+    display: table;
 
-		div {
-			float: none;
-			display: table-cell;
-			position: relative;
+    div {
+      float: none;
+      display: table-cell;
+      position: relative;
 
-			p,
-			h2,
-			h3 {
-				display: block;
-				width: 100%;
-				float: left;
-			}
+      p,
+      h2,
+      h3 {
+        display: block;
+        width: 100%;
+        float: left;
+      }
 
-			 + span img { // if image is on the right hand side
-				padding-right: 0;
-				//margin-bottom: 20px;
-			}
-		}
+       + span img { // if image is on the right hand side
+        padding-right: 0;
+        //margin-bottom: 20px;
+      }
+    }
 
-		span {
-			display: table-cell;
-			float: none;
-			position: relative;
-			text-align: center;
-			top: 0;
-			vertical-align: middle;
-			width: auto;
+    span {
+      display: table-cell;
+      float: none;
+      position: relative;
+      text-align: center;
+      top: 0;
+      vertical-align: middle;
+      width: auto;
 
-			img {
-				padding-right: 20px; // if image is on the left hand side
-			}
-		}
-	}
+      img {
+        padding-right: 20px; // if image is on the left hand side
+      }
+    }
+  }
 
 } // end @media only screen and (min-width: 984px)

--- a/scss/patterns/_inline-logos.scss
+++ b/scss/patterns/_inline-logos.scss
@@ -8,80 +8,80 @@ ul.inline-logos {
   width: 100%;
 
   li {
-	  clear: none;
-	  display: inline-block;
-	  float: none;
-	  margin: 10px 20px;
-	  padding: 0;
+    clear: none;
+    display: inline-block;
+    float: none;
+    margin: 10px 20px;
+    padding: 0;
 
-	  &.clear-row { clear: left; }
+    &.clear-row { clear: left; }
 
-	  &.last-item { border: 0; }
-	}
-	img {
-		transition: all .5s ease-out;
-		vertical-align: middle;
-	  max-width: 115px;
-	  max-height: 32px;
-	}
+    &.last-item { border: 0; }
+  }
+  img {
+    transition: all .5s ease-out;
+    vertical-align: middle;
+    max-width: 115px;
+    max-height: 32px;
+  }
 }
 
 .inline-icons {
-	margin: 0 0 $gutter-width;
+  margin: 0 0 $gutter-width;
 
-	li {
-		margin-right: 20px;
-		margin-bottom: 20px;
-		text-align: left;
-		display: inline-block;
+  li {
+    margin-right: 20px;
+    margin-bottom: 20px;
+    text-align: left;
+    display: inline-block;
 
-		&.last-item { margin-right: 0; }
-	}
+    &.last-item { margin-right: 0; }
+  }
 
-	&.no-margin-bottom li { margin-bottom: 0; }
+  &.no-margin-bottom li { margin-bottom: 0; }
 
-	img {
-		vertical-align: middle;
-	  max-width: 115px;
-	  max-height: 32px;
-	}
+  img {
+    vertical-align: middle;
+    max-width: 115px;
+    max-height: 32px;
+  }
 }
 
 @media only screen and (max-width : 768px) {
-	ul.inline-logos {
-		img {
-		  max-width: 172px;
-		  max-height: 48px;
-		}
-	}
+  ul.inline-logos {
+    img {
+      max-width: 172px;
+      max-height: 48px;
+    }
+  }
 
 } // end @media only screen and (max-width : 768px)
 
 @media only screen and (min-width : 769px) {
 
   ul.inline-logos {
-		li {
-			clear: none;
-			display: inline-block;
-			height: auto;
-			margin: 20px 0;
-			line-height: 60px;
-			padding: 0 40px;
+    li {
+      clear: none;
+      display: inline-block;
+      height: auto;
+      margin: 20px 0;
+      line-height: 60px;
+      padding: 0 40px;
 
-			img {
-				float: none;
-				vertical-align: middle;
-				max-width: 200px;
-				max-height: 45px;
-			}
-		}
-	}
+      img {
+        float: none;
+        vertical-align: middle;
+        max-width: 200px;
+        max-height: 45px;
+      }
+    }
+  }
 
 } //@media only screen and (min-width : 769px)
 
 @media only screen and (min-width: 984px) {
 
-	.inline-icons {
+  .inline-icons {
     text-align: left;
     margin-bottom: 20px;
   }

--- a/scss/patterns/_lists.scss
+++ b/scss/patterns/_lists.scss
@@ -3,18 +3,18 @@
 .list,
 .list-ubuntu,
 .list-canonical {
-	list-style: none;
-	margin-left: 0;
+  list-style: none;
+  margin-left: 0;
 
-	li {
-	  border-bottom: 1px dotted $warm-grey;
+  li {
+    border-bottom: 1px dotted $warm-grey;
     margin-bottom: 0;
     padding: 10px 0;
-	}
+  }
 
-	li:last-of-type,
+  li:last-of-type,
   li.last-item {
-	  border: 0;
+    border: 0;
     padding-bottom: 0;
   }
 }
@@ -31,13 +31,13 @@
 }
 
 nav .list a {
-	display: block;
+  display: block;
 }
 
 .list-ubuntu li,
 .list-canonical li {
-	background-repeat: no-repeat;
-	background-position: 0 1em;
+  background-repeat: no-repeat;
+  background-position: 0 1em;
   padding-left: 25px;
 }
 
@@ -113,7 +113,7 @@ html.no-svg,
 
 @media only screen and (min-width : 768px) {
 
-	.row .combined-list {
+  .row .combined-list {
     ul,
     div {
       margin-bottom: 20px;

--- a/scss/patterns/_notifications.scss
+++ b/scss/patterns/_notifications.scss
@@ -2,8 +2,8 @@
 
 div.warning {
   @include rounded-corners(4px);
-	background-color: #fdffdc;
-	color: $cool-grey;
+  background-color: #fdffdc;
+  color: $cool-grey;
 
   p {
     padding: 0;

--- a/scss/patterns/_search.scss
+++ b/scss/patterns/_search.scss
@@ -2,113 +2,113 @@
 
 .header-search,
 #box-search {
-    padding: 7px 0 7px 14px;
-    overflow: hidden;
+  padding: 7px 0 7px 14px;
+  overflow: hidden;
 
-    input[type="search"],
-    input[type="text"] {
-			-webkit-appearance: none;
-			box-shadow: inset 0 1px 4px rgba(0,0,0,0.2);
-			box-sizing: border-box;
-			border-radius: 4px;
-			transition: all .5s ease-out;
-			background-color: #be3d00;
-			border: none;
-			color: $white;
-			display: block;
-			float: left;
-			font-size: 16px;
-			height: 2.1em;
-			margin-bottom: 0;
-			padding: 0.5em 2.5em 0.5em 0.5em;
-			width: 100%;
-		}
-	  
-	  // User agents are required to ignore a rule with an unknown selector. i.e: a group of selectors containing an invalid selector is invalid.
-	  // So we need separate placeholder rules for each browser. Otherwise the whole group would be ignored by all browsers.
-    ::-webkit-input-placeholder {
-			color: white;
-			opacity: 0.4;
+  input[type="search"],
+  input[type="text"] {
+    -webkit-appearance: none;
+    box-shadow: inset 0 1px 4px rgba(0,0,0,0.2);
+    box-sizing: border-box;
+    border-radius: 4px;
+    transition: all .5s ease-out;
+    background-color: #be3d00;
+    border: none;
+    color: $white;
+    display: block;
+    float: left;
+    font-size: 16px;
+    height: 2.1em;
+    margin-bottom: 0;
+    padding: 0.5em 2.5em 0.5em 0.5em;
+    width: 100%;
+  }
+  
+  // User agents are required to ignore a rule with an unknown selector. i.e: a group of selectors containing an invalid selector is invalid.
+  // So we need separate placeholder rules for each browser. Otherwise the whole group would be ignored by all browsers.
+  ::-webkit-input-placeholder {
+    color: white;
+    opacity: 0.4;
+  }
+  ::-webkit-input-placeholder {
+    color: white;
+    opacity: 0.4;
+  }
+
+  ::-moz-placeholder {
+    color: white;
+    opacity: 0.4;
+  }
+
+  :-ms-input-placeholder {
+    color: white;
+    opacity: 0.4;
+  }
+
+  input:-moz-placeholder {
+    color: white;
+    opacity: 0.4;
+  }
+
+  ::placeholder {
+    color: white;
+    opacity: 0.4;
+  }
+
+  input[type="search"]:focus { background-color: #a63603; }
+
+  button[type=submit] {
+    padding: 3px 2px;
+    line-height: 0;
+    float: left;
+    margin-left: -40px;
+    display: block;
+    background: none;
+    overflow: visible;
+    
+    &:hover { background: none; }
+
+    img {
+      height: 28px;
+      width: 28px;
     }
-    ::-webkit-input-placeholder {
-			color: white;
-			opacity: 0.4;
-    }
-
-    ::-moz-placeholder {
-			color: white;
-			opacity: 0.4;
-    }
-
-    :-ms-input-placeholder {
-			color: white;
-			opacity: 0.4;
-    }
-
-    input:-moz-placeholder {
-			color: white;
-			opacity: 0.4;
-    }
-
-    ::placeholder {
-        color: white;
-        opacity: 0.4;
-    }
-
-    input[type="search"]:focus { background-color: #a63603; }
-
-    button[type=submit] {
-        padding: 3px 2px;
-        line-height: 0;
-        float: left;
-        margin-left: -40px;
-        display: block;
-        background: none;
-        overflow: visible;
-        
-        &:hover { background: none; }
-
-        img {
-          height: 28px;
-          width: 28px;
-        }
-    }
+  }
 }
 
 header.banner .search-toggle {
-	background-size: 20px 20px;
-	background-image: url('#{$asset-path}search_icon_white_64.png');
-	background-image: url('#{$asset-path}search.svg');
-	background-position: center center;
-	background-repeat: no-repeat;
-	display: block;
-	height: 48px;
-	outline: none;
-	overflow: hidden;
-	position: absolute;
-	right: 58px;
-	text-indent: -999em;
-	top: 0;
-	width: 24px;
+  background-size: 20px 20px;
+  background-image: url('#{$asset-path}search_icon_white_64.png');
+  background-image: url('#{$asset-path}search.svg');
+  background-position: center center;
+  background-repeat: no-repeat;
+  display: block;
+  height: 48px;
+  outline: none;
+  overflow: hidden;
+  position: absolute;
+  right: 58px;
+  text-indent: -999em;
+  top: 0;
+  width: 24px;
 }
 
 .search-toggle:link, 
 .search-toggle:active {
-	outline: none;
+  outline: none;
 }
 
 #box-search,
 .header-search {
-	background: #f0f0f0;
-	border: 0;
-	display: none;
-	float: left;
-	margin-bottom: 0;
-	position: relative;
-	margin: 0 0 -1px 0;
-	padding: 0;
-	width: 100%;
-	z-index: 3;
+  background: #f0f0f0;
+  border: 0;
+  display: none;
+  float: left;
+  margin-bottom: 0;
+  position: relative;
+  margin: 0 0 -1px 0;
+  padding: 0;
+  width: 100%;
+  z-index: 3;
 }
 
 #box-search.active,
@@ -117,25 +117,25 @@ header.banner .search-toggle {
 
 #box-search div,
 .header-search div {
-	box-shadow:	inset 0 -4px 4px -4px rgba(0, 0, 0, .3), inset 0  5px 5px -5px rgba(0, 0, 0, 0.3);
-	background: $nav-bg;
-	margin: 10px;
-	position: relative;
-	z-index: 1;
+  box-shadow:  inset 0 -4px 4px -4px rgba(0, 0, 0, .3), inset 0  5px 5px -5px rgba(0, 0, 0, 0.3);
+  background: $nav-bg;
+  margin: 10px;
+  position: relative;
+  z-index: 1;
 }
 
 #box-search form input[type="search"],
 .header-search form input[type="search"] {
-	@include font-size (16);
-	border-radius: 4px;
+  @include font-size (16);
+  border-radius: 4px;
     box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3) inset, 0 -1px 3px rgba(0, 0, 0, 0.2) inset, 0 2px 0 rgba(255, 255, 255, 0.4);
-	box-sizing: border-box;
-	background: $white;
-	border: 0;
-	color: #333;
-	font-size: 16px;
-	height: auto;
-	margin: 0;
+  box-sizing: border-box;
+  background: $white;
+  border: 0;
+  color: #333;
+  font-size: 16px;
+  height: auto;
+  margin: 0;
   float: left;
   padding: 9px 10px;
   width: 100%;
@@ -143,19 +143,19 @@ header.banner .search-toggle {
 
 .yes-js .header-inner #box-search,
 .yes-js .header-inner .header-search {
-	display: none;
+  display: none;
 
-	form {
-		box-sizing: border-box;
-		margin-left: 0;
-		margin-right: 0;
-		overflow: hidden;
-		padding: 10px;
-		top: 0;
-		z-index: 999;
-	  position: relative;
-	  width: 100%;
-	}
+  form {
+    box-sizing: border-box;
+    margin-left: 0;
+    margin-right: 0;
+    overflow: hidden;
+    padding: 10px;
+    top: 0;
+    z-index: 999;
+    position: relative;
+    width: 100%;
+  }
 }
 
 @media only screen and (max-width : 768px) {
@@ -184,18 +184,18 @@ header.banner .search-toggle {
 
 @media only screen and (min-width : 960px) {
   #box-search,
-		.header-search {
-			background: none;
-			overflow:hidden;
-			padding: 7px 0 7px 14px;
-			border-right: 0 none;
-			float: right;
-			margin-bottom: 0;
-			padding-bottom: 5px;
-			padding-right: 0;
-			padding-top: 7px;
-			max-width: 220px;
-	
+    .header-search {
+      background: none;
+      overflow:hidden;
+      padding: 7px 0 7px 14px;
+      border-right: 0 none;
+      float: right;
+      margin-bottom: 0;
+      padding-bottom: 5px;
+      padding-right: 0;
+      padding-top: 7px;
+      max-width: 220px;
+  
     form input[type="text"],
     form input[type="search"] {
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4) inset;
@@ -239,7 +239,7 @@ header.banner .search-toggle {
           display: none;
         }
       }
-		}
+    }
     .header-search.open {
       display: block;
     }
@@ -262,15 +262,15 @@ header.banner .search-toggle {
     }
    }
 
-	html.no-svg, .opera-mini {
-		header.banner .search-toggle { background-image: url("#{$asset-path}img/search-white.png"); }
-	}
+  html.no-svg, .opera-mini {
+    header.banner .search-toggle { background-image: url("#{$asset-path}img/search-white.png"); }
+  }
 
-	.opera-mini {
-		x:-o-prefocus, header.banner .search-toggle {
-		  background-size: 25px auto;
-		}
-	}
+  .opera-mini {
+    x:-o-prefocus, header.banner .search-toggle {
+      background-size: 25px auto;
+    }
+  }
 }
 
 @media only screen and (min-width: 984px) {
@@ -279,10 +279,10 @@ header.banner .search-toggle {
     display: block;
     margin-right: 0;
 
-		input[type="search"],
-		input[type="text"] {
-		}
-		
+    input[type="search"],
+    input[type="text"] {
+    }
+    
     form input[type="text"]:focus {
       width: 160px;
     }
@@ -301,154 +301,154 @@ header.banner .search-toggle {
 body.ubuntu-search,
 body.search-results,
 body.search-no-results {
-	.nav-secondary {
-		display: none;
-	}
-	section > h1, 
-	section article h1 {
-		padding-bottom: 10px;
-		font-size: 1.438em;
-		margin-bottom: 0;
-	}
-	section > h1 {
-		border-bottom: 1px dotted #dfdcd9;
-	}
-	.main-search {
-		padding: 20px 0;
-		margin: 0 0 20px 0;
-		background-color: transparent;
+  .nav-secondary {
+    display: none;
+  }
+  section > h1, 
+  section article h1 {
+    padding-bottom: 10px;
+    font-size: 1.438em;
+    margin-bottom: 0;
+  }
+  section > h1 {
+    border-bottom: 1px dotted #dfdcd9;
+  }
+  .main-search {
+    padding: 20px 0;
+    margin: 0 0 20px 0;
+    background-color: transparent;
 
-		input[type="search"] {
-			float: left;
-			width: 100%;
-			font-size: 2em;
-			border: 1px solid #999;
-			box-sizing: border-box;
-			padding: 0.2em 65px 0.2em 0.2em;
-		}
-		button[type=submit] {
-			padding: 4px;
-			line-height: 0;
-			float: left;
-			margin-left: -53px;
-			display: block;
-			background: none;
-			overflow: visible;
-			width: auto;
-			margin-top: -4px;
-			
-			&:hover {
-				background: none;
-			}
-		
-			img {
-				height: 45px;
-				width: 45px;
-			}
-		}
-	}
+    input[type="search"] {
+      float: left;
+      width: 100%;
+      font-size: 2em;
+      border: 1px solid #999;
+      box-sizing: border-box;
+      padding: 0.2em 65px 0.2em 0.2em;
+    }
+    button[type=submit] {
+      padding: 4px;
+      line-height: 0;
+      float: left;
+      margin-left: -53px;
+      display: block;
+      background: none;
+      overflow: visible;
+      width: auto;
+      margin-top: -4px;
+      
+      &:hover {
+        background: none;
+      }
+    
+      img {
+        height: 45px;
+        width: 45px;
+      }
+    }
+  }
 
-	.search-result h1 .title-main {
-		margin-right: 20px;
-	}
-	.search-result h1 .result-url {
-		color: #999;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		display: block;
-		vertical-align: bottom;
-		padding-bottom: 2px;
-	}
-	.search-result h1 .result-url a {
-		color: #999;
-	}
-	.search-result p {
-		margin-bottom: 0;
-	}
+  .search-result h1 .title-main {
+    margin-right: 20px;
+  }
+  .search-result h1 .result-url {
+    color: #999;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+    vertical-align: bottom;
+    padding-bottom: 2px;
+  }
+  .search-result h1 .result-url a {
+    color: #999;
+  }
+  .search-result p {
+    margin-bottom: 0;
+  }
 
-	.num-results {
-		display: inline-block;
-		margin-left: 20px;
-	}
+  .num-results {
+    display: inline-block;
+    margin-left: 20px;
+  }
 
-	.bottom-results-total {
-		text-align: center;
-		width: 100%;
-		overflow: visible;
-		padding-top: 20px;
-		margin: 0;
-	}
+  .bottom-results-total {
+    text-align: center;
+    width: 100%;
+    overflow: visible;
+    padding-top: 20px;
+    margin: 0;
+  }
 
-	.bottom-nav {
-		overflow: hidden;
-		margin-top: -26px;
-	}
-	.bottom-nav ul {
-		margin-bottom: 0;
-		margin-left: 0;
-		padding: 0;
-		overflow: hidden;
-	}
-	.bottom-nav li {
-		float: left;
-		margin-left: 15px;
-	}
-	.bottom-nav li:first-child {
-		margin-left: 0;
-	}
-	.nav-back {
-		float: left;
-	}
-	.nav-back li:before {
-		content: "\2039"; /* left chevron &lsaquo; */
-		color: $ubuntu_orange;
-		margin-right: 5px;
-	}
-	.nav-back li.item-extreme:before {
-		content: "\2039\2039"; /* double left chevron &lsaquo; */
-	}
-	.nav-forward {
-		float: right;
-	}
-	.nav-forward li:after {
-		content: "\203A"; /* right chevron&nbsp;&rsaquo; */
-		color: $ubuntu_orange;
-		margin-left: 5px;
-	}
-	.nav-forward li.item-extreme:after {
-		content: "\203A\203A"; /* double right chevron&nbsp;&rsaquo; */
-	}
-	
-	.error-notification {
-		background-color: #fdffdc;
-		color: #333;
-		padding: 20px;
-		box-sizing: border-box;
-		width: 100%;
-		margin-top: 20px;
-		display: block;
-	}
-	
-	.result-line {
-		color: #ada69e;
-	}
-	.results-top {
-		border-bottom: 1px dotted #dfdcd9;
-		padding-bottom: 0.5em;
-	}
-	
-	.search-container {
-		padding-bottom: 0;
-	}
+  .bottom-nav {
+    overflow: hidden;
+    margin-top: -26px;
+  }
+  .bottom-nav ul {
+    margin-bottom: 0;
+    margin-left: 0;
+    padding: 0;
+    overflow: hidden;
+  }
+  .bottom-nav li {
+    float: left;
+    margin-left: 15px;
+  }
+  .bottom-nav li:first-child {
+    margin-left: 0;
+  }
+  .nav-back {
+    float: left;
+  }
+  .nav-back li:before {
+    content: "\2039"; /* left chevron &lsaquo; */
+    color: $ubuntu_orange;
+    margin-right: 5px;
+  }
+  .nav-back li.item-extreme:before {
+    content: "\2039\2039"; /* double left chevron &lsaquo; */
+  }
+  .nav-forward {
+    float: right;
+  }
+  .nav-forward li:after {
+    content: "\203A"; /* right chevron&nbsp;&rsaquo; */
+    color: $ubuntu_orange;
+    margin-left: 5px;
+  }
+  .nav-forward li.item-extreme:after {
+    content: "\203A\203A"; /* double right chevron&nbsp;&rsaquo; */
+  }
+  
+  .error-notification {
+    background-color: #fdffdc;
+    color: #333;
+    padding: 20px;
+    box-sizing: border-box;
+    width: 100%;
+    margin-top: 20px;
+    display: block;
+  }
+  
+  .result-line {
+    color: #ada69e;
+  }
+  .results-top {
+    border-bottom: 1px dotted #dfdcd9;
+    padding-bottom: 0.5em;
+  }
+  
+  .search-container {
+    padding-bottom: 0;
+  }
 }
 
 @media only screen and (min-width : 768px) {
-	.ubuntu-search {
-		.main-search {
-			button[type=submit] {
-				margin-left: -60px;
-				margin-top: 0;
-			}
-		}
-	}
+  .ubuntu-search {
+    .main-search {
+      button[type=submit] {
+        margin-left: -60px;
+        margin-top: 0;
+      }
+    }
+  }
 } /* end @media only screen and (min-width : 768px) */

--- a/scss/patterns/_structure.scss
+++ b/scss/patterns/_structure.scss
@@ -7,33 +7,33 @@ header.banner .nav-primary,
 nav div.footer-a div,
 .inline-lists ul,
 .legal {
-	box-sizing: border-box;
-	width: auto;
+  box-sizing: border-box;
+  width: auto;
 }
 
 .inner-wrapper {
-	box-sizing: border-box;
-	background: $white;
-	clear: both;
-	display: block;
-	float: left;
-	width: 100%;
-	margin: 0;
-	padding-bottom: 20px;
-	position: relative;
-	z-index: 1;
+  box-sizing: border-box;
+  background: $white;
+  clear: both;
+  display: block;
+  float: left;
+  width: 100%;
+  margin: 0;
+  padding-bottom: 20px;
+  position: relative;
+  z-index: 1;
 }
 
 @media only screen and (min-width : 768px) {
-	.med-six-col {
-		.three-col {
-			width: 48%;
-		}
+  .med-six-col {
+    .three-col {
+      width: 48%;
+    }
 
-		.three-col:nth-of-type(2n) {
-			margin-right: 0;
-		}
-	}
+    .three-col:nth-of-type(2n) {
+      margin-right: 0;
+    }
+  }
 
 } // end @media only screen and (max-width : 768px)
 
@@ -47,38 +47,38 @@ nav div.footer-a div,
 
 @media only screen and (min-width: 984px) {
 
-	.wrapper {
-		box-sizing: border-box;
-		background: $white;
-		margin: 0 auto;
-		position: relative;
-		text-align: left;
-		width: 984px;
-	}
+  .wrapper {
+    box-sizing: border-box;
+    background: $white;
+    margin: 0 auto;
+    position: relative;
+    text-align: left;
+    width: 984px;
+  }
 
-	.inner-wrapper {
-		box-shadow: 0 0 3px #c9c9c9;
-		margin: 10px 0 30px;
-	}
+  .inner-wrapper {
+    box-shadow: 0 0 3px #c9c9c9;
+    margin: 10px 0 30px;
+  }
 
-	.three-col,
-	.med-six-col .three-col {
-		width: 23.30%;
-	}
+  .three-col,
+  .med-six-col .three-col {
+    width: 23.30%;
+  }
 
-	.three-col.last-col:nth-of-type(2n) {
+  .three-col.last-col:nth-of-type(2n) {
     margin-right: 0;
   }
 
-	.med-six-col {
-		.three-col:nth-of-type(2n) {
-		    margin-right: 20px;
-		}
+  .med-six-col {
+    .three-col:nth-of-type(2n) {
+        margin-right: 20px;
+    }
 
-		.three-col.last-col {
-			margin-right: 0;
-		}
-	}
+    .three-col.last-col {
+      margin-right: 0;
+    }
+  }
 
 } // end @media only screen and (min-width: 984px)
 

--- a/scss/patterns/_tabbed-content.scss
+++ b/scss/patterns/_tabbed-content.scss
@@ -22,9 +22,9 @@ html.yui3-js-enabled {
   }
 
   .tabbed-content {
-			border-radius: 4px;
-			padding: 8px 8px 0;
-    	background: $light-grey;
+      border-radius: 4px;
+      padding: 8px 8px 0;
+      background: $light-grey;
       margin-bottom: 8px;
 
       &.hide {
@@ -203,8 +203,8 @@ html.yui3-js-enabled {
     padding-right: 0;
   }
   
-	html.yui3-js-enabled .arrow {
-		visibility: visible;
-	}
+  html.yui3-js-enabled .arrow {
+    visibility: visible;
+  }
   
 }

--- a/scss/patterns/_vertical-divider.scss
+++ b/scss/patterns/_vertical-divider.scss
@@ -57,9 +57,9 @@
 
 @media only screen and (min-width: 984px) {
 
-	.row.vertical-divider {
-	  padding-bottom: 60px;
-	}
+  .row.vertical-divider {
+    padding-bottom: 60px;
+  }
 
   .vertical-divider {
     > div,

--- a/scss/patterns/patterns.scss
+++ b/scss/patterns/patterns.scss
@@ -5,9 +5,9 @@
  *
  * The CSS file required by Ubuntu patterns page
  *
- * @project		Ubuntu Patterns
- * @author		Web Team at Canonical Ltd
- * @copyright	2014 Canonical Ltd
+ * @project    Ubuntu Patterns
+ * @author    Web Team at Canonical Ltd
+ * @copyright  2014 Canonical Ltd
  *
  */
 


### PR DESCRIPTION
Spacing in scss files looks like a mess in commits, because there are tabs littered everywhere.

This replaces all tab characters with two spaces in SCSS files.

Done
---

- Replaced all tab characters with 2 spaces in scss files

QA
---

- Run `gulp sass`, make sure it still compiles
- Ensure you're okay with the concept of having to merge all the files with everyone else's work