### PR TITLE
Add optional param to test to only test a single file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,8 @@ gulp.task('help', function() {
 });
 
 gulp.task('sasslint', function() {
-    return gulp.src('scss/**/*.scss')
+    var path = (gutil.env.file)? gutil.env.file : '**/*.scss';
+    return gulp.src('scss/' + path)
         .pipe(scsslint())
         .pipe(scsslint.failReporter());
 });


### PR DESCRIPTION
# Details
- None

## Done
- Added a small bit of logic in the gulp test task

### QA
- Run ```gulp test``` and see all the warnings and errors for all files
- Run ```gulp test --file patterns/patterns.scss``` to only lint that file