### PR TITLE
Changing test file to full path

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,8 +32,8 @@ gulp.task('help', function() {
 });
 
 gulp.task('sasslint', function() {
-    var path = (gutil.env.file)? gutil.env.file : '**/*.scss';
-    return gulp.src('scss/' + path)
+    var path = (gutil.env.file)? gutil.env.file : 'scss/**/*.scss';
+    return gulp.src(path)
         .pipe(scsslint())
         .pipe(scsslint.failReporter());
 });


### PR DESCRIPTION
# Details
- None

## Done
- Changed the path required for the test param to include scss/ so its the full path

### QA
- Run ```gulp test``` and see if checks all files
- Run ```gulp test --file scss/patterns/_image-centered.scss``` and check it only checks that file
- Try tab completing the file path as its relative