### PR TITLE
Update readme install instructions; change "install-dependencies" to "dependencies" to save peoples fingers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl -L https://npmjs.com/install.sh | sudo sh`
 Install all other dependencies:
 
 ``` bash
-npm install-dependencies
+npm run-script dependencies
 ```
 
 ## Themes

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Ubuntu web style guide",
   "private": true,
   "scripts": {
-    "install-dependencies": "./.install_dependencies.sh",
+    "dependencies": "./.install_dependencies.sh",
     "clean": "rm -r build; rm -r node_modules"
   },
   "repository": {


### PR DESCRIPTION
Done:

- Changed name of npm dependencies script
- Update README to have commands which actually work

QA:

- Run the dependencies command from the readme.