### PR TITLE
Simplify installation of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
 node_js:
   - "0.10.25"
-before_install:
-  - gem update --system
-  - gem install scss-lint
 script: node_modules/gulp/bin/gulp.js test

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ curl -L https://npmjs.com/install.sh | sudo sh`
 Install all other dependencies:
 
 ``` bash
-npm run-script dependencies  # System dependencies
 npm install                  # NodeJS dependencies
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Ubuntu web style guide",
   "private": true,
   "scripts": {
-    "dependencies": "./.install_dependencies.sh",
+    "prepublish": "./.install_dependencies.sh",
     "clean": "rm -r build; rm -r node_modules"
   },
   "repository": {


### PR DESCRIPTION
By using the `prepublish` step in `package.json`, it means .install-dependencies.sh
will be run automatically on `npm install`, simplifying setup for everyone.

This is now possible because the dependencies script should now work on travis as well
so the same dependencies script can be run anywhere.

Done
---

- Make install-dependencies script more robust
- Install dependencies on npm prepublish
  * So now `npm install` will install everything in one step
  * Updated README to reflect this
- Remove gem dependencies from travis yaml

QA
---

1. Check travis passes for this build
2. Delete `gulp` and `scss-lint` locally  
   (`sudo npm uninstall -g gulp`, `sudo gem uninstall scss-lint`)  
   Now run `npm install` and make sure `gulp` and `scss-lint` are installed